### PR TITLE
Add "speaker-selection" permissions policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A web platform API which gives a website the ability to allow and deny the use of browser features in its own frame, and in iframes that it embeds. Examples of [features](https://github.com/w3c/webappsec-feature-policy/blob/master/features.md) that could be controlled by permissions policy include:
 
-- getUserMedia (Camera and Microphone)
+- getUserMedia (Camera, Microphone, and Speaker-selection)
 - Fullscreen
 - Geolocation
 - MIDI

--- a/features.md
+++ b/features.md
@@ -50,6 +50,7 @@ integrated into their respective specs.
 | ------------ | --------------- | --------------- |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
 | `geolocation` | https://github.com/w3c/permissions/pull/163 | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
 
 ## Experimental Features
 


### PR DESCRIPTION
The recently added [selectAudioOutput](https://w3c.github.io/mediacapture-output/#dom-mediadevices-selectaudiooutput) API needs to be restricted in iframes since it prompts the user.

We are adding back the `"speaker-selection"` (formerly `"speaker"`¹) permissions policy in https://github.com/w3c/mediacapture-output/pull/96.

---
<sub>1. The old name had folks thinking an iframe without `allow="speaker"` would be silent. The new name clarifies the powerful feature in question is instead the ability to request and output to non-default audio output devices.</sub>