### PR TITLE
Fix this version and repository links to avoid redirects

### DIFF
--- a/document-policy.bs
+++ b/document-policy.bs
@@ -5,10 +5,10 @@ Level: 1
 Indent: 2
 Status: ED
 Group: WebAppSec
-URL: https://w3c.github.io/webappsec-feature-policy/document-policy.html
+URL: https://w3c.github.io/webappsec-permissions-policy/document-policy.html
 Editor: Ian Clelland, Google, iclelland@google.com
 Abstract: This specification defines a mechanism that allows developers to ...
-Repository: https://github.com/w3c/webappsec-feature-policy/
+Repository: https://github.com/w3c/webappsec-permissions-policy/
 Markup Shorthands: css no, markdown yes
 </pre>
 <pre class="link-defaults">

--- a/index.bs
+++ b/index.bs
@@ -5,10 +5,10 @@ Level: 1
 Indent: 2
 Status: ED
 Group: WebAppSec
-URL: https://w3c.github.io/webappsec-feature-policy/
+URL: https://w3c.github.io/webappsec-permissions-policy/
 Editor: Ian Clelland, Google, iclelland@google.com
 Abstract: This specification defines a mechanism that allows developers to selectively enable and disable use of various browser features and APIs.
-Repository: https://github.com/w3c/webappsec-feature-policy/
+Repository: https://github.com/w3c/webappsec-permissions-policy/
 Markup Shorthands: css no, markdown yes
 </pre>
 <pre class="link-defaults">


### PR DESCRIPTION
Fix the URL and Repository fields to use the new URL (webappsec-permissions-policy) rather than the old one (webappsec-feature-policy).

Fixes #403.