### PR TITLE
Allow header to enable features.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -932,6 +932,9 @@ partial interface HTMLIFrameElement {
         1. If the <a>allowlist</a> for |feature| in |container policy|
           <a>matches</a> |origin|, return "<code>Enabled</code>".
         1. Otherwise return "<code>Disabled</code>".
+    1. If |feature| is present in |policy|’s <a>declared policy</a>, and the
+      <a>allowlist</a> for |feature| in |policy|’s <a>declared policy</a>
+      <a>matches</a> |origin|, then return "<code>Enabled</code>".
     1. If |feature|'s <a>default allowlist</a> is <code>*</code>, return
       "<code>Enabled</code>".
     1. If |feature|'s <a>default allowlist</a> is <code>'self'</code>, and


### PR DESCRIPTION
This allows the header alone to enable delegation of a feature to specific
origins, if not otherwise blocked or affected by the container policy. The
order of precedence becomes:

1. Explicitly blocked by header: Disabled
2. Explicitly blocked by allow attribute: Disabled
3. Explicitly allowed by allow attribute: Enabled
4. Explicitly allowed by header: Enabled
5a. (Default behaviour when default allowlist is '*'): Enabled
5b. (Default behaviour when default allowlist is 'self'): Enabled if same-
    origin; Disabled if cross-origin.

Fixes: #408