### PR TITLE
Default allowlists only effect child browsing contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -308,22 +308,19 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <h3 id="default-allowlists">Default Allowlists</h3>
     <p>Every <a>policy-controlled feature</a> has a <dfn export lt=
     "default allowlist|default allowlists">default allowlist</dfn>. The
-    <a>default allowlist</a> determines whether the feature is allowed in a
-    document with no declared policy in a top-level browsing context, and also
-    whether access to the feature is automatically delegated to documents in
-    child browsing contexts.</p>
+    <a>default allowlist</a> determines whether the feature is automatically
+    delegated to documents in child browsing contexts.</p>
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
       <dt><code>*</code></dt>
-      <dd>The feature is allowed in documents in top-level browsing contexts by
-      default, and when allowed, is allowed by default to documents in child
-      browsing contexts.</dd>
+      <dd>When allowed in the top-level document, the feature is delegated by
+      default to documents in child browsing contexts.</dd>
       <dt><code>'self'</code></dt>
-      <dd>The feature is allowed in documents in top-level browsing contexts by
-      default, and when allowed, is allowed by default to same-origin domain
-      documents in child browsing contexts, but is disallowed by default in
-      cross-origin documents in child browsing contexts.</dd>
+      <dd>When allowed in the top-level document, the feature is delegated by
+      default to same-origin domain documents in child browsing contexts, but is
+      not delegated by default to cross-origin documents in child browsing
+      contexts.</dd>
     </dl>
   </section>
 </section>


### PR DESCRIPTION
This change updates the definition of a "default allowlist" to clarify
that it only effects feature availability in child browsing contexts.
That is, a feature is always available by default in a top-level
browsing context but may be specified with a default allowlist of '*' or
'self' in order to control whether the feature is available by default
in cross-origin documents in child browsing contexts.