### PR TITLE
Add new permission policy features

### DIFF
--- a/features.md
+++ b/features.md
@@ -73,6 +73,7 @@ experimentation by web developers.
 
 | Feature name | Link(s) | Browser Support |
 | ------------ | ------- | --------------- |
+| `attribution-reporting` | [Attribution Reporting API](https://wicg.github.io/conversion-measurement-api/#permission-policy-integration) | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | Status "[Started](https://bugs.chromium.org/p/chromium/issues/detail?id=1294456)" in Chrome |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |

--- a/features.md
+++ b/features.md
@@ -57,7 +57,7 @@ specification.
 | `idle-detection` | [Idle Detection API][idle-detection] | [Chrome 94](https://chromestatus.com/feature/4590256452009984) |
 | `keyboard-map` | [Keyboard Map API][keyboard-map] | [Chrome 97](https://chromestatus.com/feature/5657965899022336) |
 | `local-fonts` | [Local Font Access API][local-fonts-access] |  [Chrome 103](https://chromestatus.com/feature/6234451761692672) |
-| `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
+| `magnetometer` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `microphone` |[Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |

--- a/features.md
+++ b/features.md
@@ -97,6 +97,7 @@ experimentation by web developers.
 | `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5646861215989760) in Chrome 100-104 |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
+| `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Explainer](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/2479231594867458049) in Chrome 84-87 |
 | `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -153,6 +154,7 @@ names will be added to this list as they are actually defined.
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
 [interest-cohort]: https://wicg.github.io/floc/#permissions-policy-integration
+[join-ad-interest-group]: https://github.com/WICG/turtledove/blob/main/FLEDGE.md#11-joining-interest-groups
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature

--- a/features.md
+++ b/features.md
@@ -101,6 +101,7 @@ names will be added to this list as they are actually defined.
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
 [bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
 [ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features
+[direct-sockets]: https://wicg.github.io/direct-sockets/#permissions-policy
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy

--- a/features.md
+++ b/features.md
@@ -110,7 +110,7 @@ different feature name.
 
 | Feature name | Spec link(s) | Browser Support | Description |
 | ------------ | ------------ | --------------- | ----------- |
-| `interest-cohort` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
+| `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
 
 
 ## Notes
@@ -152,6 +152,7 @@ names will be added to this list as they are actually defined.
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
+[interest-cohort]: https://wicg.github.io/floc/#permissions-policy-integration
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature

--- a/features.md
+++ b/features.md
@@ -69,7 +69,7 @@ specification.
 | `sync-xhr` | [XMLHttpRequest][xhr] | [Chrome 65](https://www.chromestatus.com/feature/5154875084111872) |
 | `usb` | [WebUSB][webusb] | [Chrome 61](https://chromestatus.com/feature/5651917954875392) |
 | `vertical-scroll` | [Vertical Scroll](policies/vertical_scroll.md) | [Chrome 88](https://caniuse.com/permissions-policy) |
-| `web-share` | [Web Share API][web-share] | Chrome 86 |
+| `web-share` | [Web Share API][web-share] | [Chrome 86](https://chromestatus.com/feature/5668769141620736) |
 | `xr-spatial-tracking`<sup>[2](#fn2)</sup> | [WebXR Device API][xr] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
 
 ## Proposed Features

--- a/features.md
+++ b/features.md
@@ -118,6 +118,7 @@ different feature name.
 | `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead |
 | `conversion-measurement` | [Attribution Reporting API][conversion-measurement] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 | `conversion-measurement` has been renamed to `attribution-reporting` |
 | `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/) |
+| `shared-autofill` | | [Chromium team info](https://groups.google.com/a/chromium.org/g/blink-reviews/c/vxrAOYtUrXg/m/CFXkm3z7AAAJ) | Chrome has disabled the feature by default and reverting the `shared-autofill` feature |
 | `sync-script` | [Document Policy][sync-script] | [Pending Chrome Feature](https://chromestatus.com/feature/6218263637786624) | `sync-script` has been taken from [Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) and been added to [Document Policy API](https://wicg.github.io/document-policy/) instead of [Permissions Policy API](https://w3c.github.io/webappsec-permissions-policy/) |
 
 

--- a/features.md
+++ b/features.md
@@ -99,6 +99,8 @@ experimentation by web developers.
 | `attribution-reporting` | [Attribution Reporting API][attribution-reporting] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | In [Origin Trial](https://chromestatus.com/feature/5680923054964736) in Chrome 101-104 |
 | `ch-partitioned-cookies` | [CHIPS (Cookies Having Independent Partitioned State)](https://github.com/WICG/CHIPS) | In [Origin Trial](https://chromestatus.com/feature/5179189105786880) in Chrome 100-102 |
+| `ch-ua-full` | [User-Agent Reduction Origin Trial and Dates](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/2608710084154359809) in Chrome 100-113 |
+| `ch-ua-reduced` | [User-Agent Reduction Origin Trial and Dates](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-7123568710593282047) in Chrome 95-103 |
 | `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5646861215989760) in Chrome 100-104 |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
@@ -113,10 +115,9 @@ different feature name.
 
 | Feature name | Spec link(s) | Browser Support | Description |
 | ------------ | ------------ | --------------- | ----------- |
-| `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead. |
+| `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead |
 | `conversion-measurement` | [Attribution Reporting API][conversion-measurement] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 | `conversion-measurement` has been renamed to `attribution-reporting` |
-| `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
-
+| `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/) |
 | `sync-script` | [Document Policy][sync-script] | [Pending Chrome Feature](https://chromestatus.com/feature/6218263637786624) | `sync-script` has been taken from [Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) and been added to [Document Policy API](https://wicg.github.io/document-policy/) instead of [Permissions Policy API](https://w3c.github.io/webappsec-permissions-policy/) |
 
 

--- a/features.md
+++ b/features.md
@@ -60,7 +60,6 @@ specification.
 | `magnetometer` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `microphone` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
-| `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `otp-credentials` | [WebOTP API][otp-credentials] | [Chrome 84](https://chromestatus.com/feature/5873577578463232) |
 | `payment` | [Payment Request API][payment-request] | [Chrome 62](https://chromestatus.com/feature/5639348045217792)] |
 | `picture-in-picture` | [Picture-in-Picture (PIP) API][pip] | [Chrome 72](https://chromestatus.com/feature/5729206566649856) |
@@ -85,6 +84,7 @@ integrated into their respective specs.
 | `ch-prefers-forced-colors` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | See above |
 | `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
+| `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | [Behind a flag in Firefox 92](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/speaker-selection) |
 
 ## Experimental Features

--- a/features.md
+++ b/features.md
@@ -52,7 +52,7 @@ specification.
 | `fullscreen` | [Fullscreen API][fullscreen] | [Chrome 62](https://www.chromestatus.com/feature/5094837900541952) |
 | `gamepad` | [Gamepad API][gamepad] | [Chrome 86](https://chromestatus.com/feature/5138714634223616) |
 | `geolocation` | [Geolocation API][geolocation] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
-| `gyroscope` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
+| `gyroscope` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `hid` | [WebHID API][webhid] | [Chrome 89](https://chromestatus.com/feature/5172464636133376) |
 | `idle-detection` | [Idle Detection API][idle-detection] | [Chrome 94](https://chromestatus.com/feature/4590256452009984) |
 | `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |

--- a/features.md
+++ b/features.md
@@ -58,7 +58,7 @@ specification.
 | `keyboard-map` | [Keyboard Map API][keyboard-map] | [Chrome 97](https://chromestatus.com/feature/5657965899022336) |
 | `local-fonts` | [Local Font Access API][local-fonts-access] |  [Chrome 103](https://chromestatus.com/feature/6234451761692672) |
 | `magnetometer` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
-| `microphone` |[Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `microphone` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `payment` | [Payment Request API][payment-request] | Chrome 60 |

--- a/features.md
+++ b/features.md
@@ -107,8 +107,8 @@ names will be added to this list as they are actually defined.
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
-[media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
+[media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature
 [page-lifecycle]: https://wicg.github.io/page-lifecycle/#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#permissions-policy

--- a/features.md
+++ b/features.md
@@ -62,7 +62,7 @@ specification.
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `payment` | [Payment Request API][payment-request] | [Chrome 62](https://chromestatus.com/feature/5639348045217792)] |
-| `picture-in-picture` | [Picture-in-Picture][pip] | Shipped in Chrome |
+| `picture-in-picture` | [Picture-in-Picture (PIP) API][pip] | [Chrome 72](https://chromestatus.com/feature/5729206566649856) |
 | `publickey-credentials-get` | [Web Authentication API][publickey-credentials-get] | [Chrome 70](https://chromestatus.com/feature/5669923372138496) |
 | `screen-wake-lock` | [Wake Lock API][wake-lock] | [Chrome 84](https://www.chromestatus.com/feature/4636879949398016) |
 | `serial` | [Web Serial API][web-serial] | [Chrome 89](https://chromestatus.com/feature/6577673212002304) |

--- a/features.md
+++ b/features.md
@@ -61,7 +61,7 @@ specification.
 | `microphone` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
-| `payment` | [Payment Request API][payment-request] | Chrome 60 |
+| `payment` | [Payment Request API][payment-request] | [Chrome 62](https://chromestatus.com/feature/5639348045217792)] |
 | `picture-in-picture` | [Picture-in-Picture][pip] | Shipped in Chrome |
 | `publickey-credentials-get` | [Web Authentication API][publickey-credentials-get] | [Chrome 70](https://chromestatus.com/feature/5669923372138496) |
 | `screen-wake-lock` | [Wake Lock API][wake-lock] | [Chrome 84](https://www.chromestatus.com/feature/4636879949398016) |

--- a/features.md
+++ b/features.md
@@ -74,7 +74,7 @@ experimentation by web developers.
 | Feature name | Link(s) | Browser Support |
 | ------------ | ------- | --------------- |
 | `attribution-reporting` | [Attribution Reporting API][attribution-reporting] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
-| `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | Status "[Started](https://bugs.chromium.org/p/chromium/issues/detail?id=1294456)" in Chrome |
+| `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | In [Origin Trial](https://chromestatus.com/feature/5680923054964736) in Chrome 101-104 |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |

--- a/features.md
+++ b/features.md
@@ -93,7 +93,7 @@ experimentation by web developers.
 | `attribution-reporting` | [Attribution Reporting API][attribution-reporting] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | In [Origin Trial](https://chromestatus.com/feature/5680923054964736) in Chrome 101-104 |
 | `ch-partitioned-cookies` | [CHIPS (Cookies Having Independent Partitioned State)](https://github.com/WICG/CHIPS) | In [Origin Trial](https://chromestatus.com/feature/5179189105786880) in Chrome 100-102 |
-| `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial]([https://chromestatus.com/feature/5179189105786880](https://chromestatus.com/feature/5646861215989760)) in Chrome 100-104 |
+| `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5646861215989760) in Chrome 100-104 |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |

--- a/features.md
+++ b/features.md
@@ -104,7 +104,7 @@ experimentation by web developers.
 
 ## Deprecated Features
 
-These features that were added to a browser and are still listed in the 
+These features were added to a browser and are still listed in the 
 browsers source code, but have since been deprecated or replaced with a 
 different feature name.
 

--- a/features.md
+++ b/features.md
@@ -20,7 +20,9 @@ specification.
 | `ambient-light-sensor` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `autoplay` | [HTML][html] | [Chrome 64](https://www.chromestatus.com/feature/5100524789563392) |
 | `battery` | [Battery Status API][battery-status] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=1007264)" in Chrome |
+| `bluetooth` | [Web Bluetooth API](https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy) | [Chrome 104](https://chromestatus.com/feature/6439287120723968) |
 | `camera` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `ch-prefers-color-scheme` | [User Preference Media Features Client Hints Headers](https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features) | [Chrome 93](https://chromestatus.com/feature/5642300464037888) |
 | `cross-origin-isolated` | [HTML][html] | Experimental in Chrome 85 |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -53,9 +55,14 @@ integrated into their respective specs.
 
 | Feature name | Spec/PR link(s) | Browser Support |
 | ------------ | --------------- | --------------- |
+| `ch-prefers-reduced-motion` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
+| `ch-prefers-reduced-transparency` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
+| `ch-prefers-contrast` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
+| `ch-prefers-forced-colors` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
 | `clipboard-read` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
 | `clipboard-write` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
+| `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
 | `gamepad` | https://github.com/w3c/gamepad/pull/112 |  |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
 
@@ -92,14 +99,16 @@ names will be added to this list as they are actually defined.
 `--enable-blink-features=ConversionMeasurement`.
 
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
+[bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
+[ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
-[media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
+[media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature
 [page-lifecycle]: https://wicg.github.io/page-lifecycle/#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#permissions-policy

--- a/features.md
+++ b/features.md
@@ -42,7 +42,7 @@ specification.
 | `ch-width` | [User-Agent Client Hints][ch-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
 | `clipboard-read` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
 | `clipboard-write` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
-| `cross-origin-isolated` | [HTML][html] | Experimental in Chrome 85 |
+| `cross-origin-isolated` | [HTML][html] | [Chrome 87](https://chromestatus.com/feature/5690888397258752) |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `encrypted-media` | [Encrypted Media Extensions][encrypted-media] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |

--- a/features.md
+++ b/features.md
@@ -20,9 +20,9 @@ specification.
 | `ambient-light-sensor` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `autoplay` | [HTML][html] | [Chrome 64](https://www.chromestatus.com/feature/5100524789563392) |
 | `battery` | [Battery Status API][battery-status] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=1007264)" in Chrome |
-| `bluetooth` | [Web Bluetooth API](https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy) | [Chrome 104](https://chromestatus.com/feature/6439287120723968) |
+| `bluetooth` | [Web Bluetooth API][bluetooth] | [Chrome 104](https://chromestatus.com/feature/6439287120723968) |
 | `camera` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
-| `ch-prefers-color-scheme` | [User Preference Media Features Client Hints Headers](https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features) | [Chrome 93](https://chromestatus.com/feature/5642300464037888) |
+| `ch-prefers-color-scheme` | [User Preference Media Features Client Hints Headers][ch-prefers-color-scheme] | [Chrome 93](https://chromestatus.com/feature/5642300464037888) |
 | `cross-origin-isolated` | [HTML][html] | Experimental in Chrome 85 |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -73,7 +73,7 @@ experimentation by web developers.
 
 | Feature name | Link(s) | Browser Support |
 | ------------ | ------- | --------------- |
-| `attribution-reporting` | [Attribution Reporting API](https://wicg.github.io/conversion-measurement-api/#permission-policy-integration) | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
+| `attribution-reporting` | [Attribution Reporting API][attribution-reporting] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | Status "[Started](https://bugs.chromium.org/p/chromium/issues/detail?id=1294456)" in Chrome |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
@@ -99,6 +99,7 @@ names will be added to this list as they are actually defined.
 <a name="fn5">[5]</a>: To enable this, use the Chrome command line flag
 `--enable-blink-features=ConversionMeasurement`.
 
+[attribution-reporting]: https://wicg.github.io/conversion-measurement-api/#permission-policy-integration
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
 [bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
 [ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features

--- a/features.md
+++ b/features.md
@@ -101,6 +101,7 @@ experimentation by web developers.
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
+| `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Explainer](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/2479231594867458049) in Chrome 84-87 |
 | `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |

--- a/features.md
+++ b/features.md
@@ -103,7 +103,6 @@ experimentation by web developers.
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
-| `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Trust Token API](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://chromestatus.com/feature/5078049450098688) in Chrome 84-101 |
 
 ## Deprecated Features
@@ -117,6 +116,8 @@ different feature name.
 | `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead. |
 | `conversion-measurement` | [Attribution Reporting API][conversion-measurement] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 | `conversion-measurement` has been renamed to `attribution-reporting` |
 | `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
+
+| `sync-script` | [Document Policy][sync-script] | [Pending Chrome Feature](https://chromestatus.com/feature/6218263637786624) | `sync-script` has been taken from [Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) and been added to [Document Policy API](https://wicg.github.io/document-policy/) instead of [Permissions Policy API](https://w3c.github.io/webappsec-permissions-policy/) |
 
 
 ## Notes
@@ -169,6 +170,7 @@ names will be added to this list as they are actually defined.
 [payment-request]: https://www.w3.org/TR/payment-request/#permissions-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy
 [publickey-credentials-get]: https://w3c.github.io/webauthn/#sctn-permissions-policy
+[sync-script]: https://github.com/WICG/document-policy/issues/2
 [wake-lock]: https://w3c.github.io/screen-wake-lock/#policy-control
 [web-midi]: https://webaudio.github.io/web-midi-api/#permissions-policy-integration
 [web-serial]: https://wicg.github.io/serial/#permissions-policy

--- a/features.md
+++ b/features.md
@@ -55,6 +55,7 @@ specification.
 | `gyroscope` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `hid` | [WebHID API][webhid] | [Chrome 89](https://chromestatus.com/feature/5172464636133376) |
 | `idle-detection` | [Idle Detection API][idle-detection] | [Chrome 94](https://chromestatus.com/feature/4590256452009984) |
+| `keyboard-map` | [Keyboard Map API][keyboard-map] | [Chrome 97](https://chromestatus.com/feature/5657965899022336) |
 | `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `microphone` |[Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
@@ -155,6 +156,7 @@ names will be added to this list as they are actually defined.
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
 [interest-cohort]: https://wicg.github.io/floc/#permissions-policy-integration
 [join-ad-interest-group]: https://github.com/WICG/turtledove/blob/main/FLEDGE.md#11-joining-interest-groups
+[keyboard-map]: https://wicg.github.io/keyboard-map/#permissions-policy
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature

--- a/features.md
+++ b/features.md
@@ -67,7 +67,7 @@ specification.
 | `screen-wake-lock` | [Wake Lock API][wake-lock] | [Chrome 84](https://www.chromestatus.com/feature/4636879949398016) |
 | `serial` | [Web Serial API][web-serial] | [Chrome 89](https://chromestatus.com/feature/6577673212002304) |
 | `sync-xhr` | [XMLHttpRequest][xhr] | [Chrome 65](https://www.chromestatus.com/feature/5154875084111872) |
-| `usb` | [WebUSB][webusb] | Chrome 60 |
+| `usb` | [WebUSB][webusb] | [Chrome 61](https://chromestatus.com/feature/5651917954875392) |
 | `web-share` | [Web Share API][web-share] | Chrome 86 |
 | `xr-spatial-tracking`<sup>[2](#fn2)</sup> | [WebXR Device API][xr] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
 

--- a/features.md
+++ b/features.md
@@ -44,7 +44,7 @@ specification.
 | `clipboard-write` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
 | `cross-origin-isolated` | [HTML][html] | [Chrome 87](https://chromestatus.com/feature/5690888397258752) |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | [Chrome 94](https://chromestatus.com/feature/5144822362931200) |
-| `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
+| `document-domain` | [HTML][html] | [Chrome 77](https://chromestatus.com/feature/5341992867332096) |
 | `encrypted-media` | [Encrypted Media Extensions][encrypted-media] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `execution-while-not-rendered` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `execution-while-out-of-viewport` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |

--- a/features.md
+++ b/features.md
@@ -102,6 +102,16 @@ experimentation by web developers.
 | `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `window-placement` | [Explainer](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-8087339030850568191) in Chrome 93-96 |
 
+## Deprecated Features
+
+These features that were added to a browser and are still listed in the 
+browsers source code, but have since been deprecated or replaced with a 
+different feature name.
+
+| Feature name | Spec link(s) | Browser Support | Description |
+| ------------ | ------------ | --------------- | ----------- |
+| `interest-cohort` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
+
 
 ## Notes
 

--- a/features.md
+++ b/features.md
@@ -103,7 +103,7 @@ experimentation by web developers.
 | `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
-| `trust-token-redemption` | [Explainer](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/2479231594867458049) in Chrome 84-87 |
+| `trust-token-redemption` | [Trust Token API](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://chromestatus.com/feature/5078049450098688) in Chrome 84-101 |
 | `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `window-placement` | [Explainer](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-8087339030850568191) in Chrome 93-96 |
 

--- a/features.md
+++ b/features.md
@@ -63,7 +63,7 @@ specification.
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `payment` | [Payment Request API][payment-request] | Chrome 60 |
 | `picture-in-picture` | [Picture-in-Picture][pip] | Shipped in Chrome |
-| `publickey-credentials-get` | [Web Authentication API][publickey-credentials-get] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=993007)" in Chrome |
+| `publickey-credentials-get` | [Web Authentication API][publickey-credentials-get] | [Chrome 70](https://chromestatus.com/feature/5669923372138496) |
 | `screen-wake-lock` | [Wake Lock API][wake-lock] | [Chrome 84](https://www.chromestatus.com/feature/4636879949398016) |
 | `serial` | [Web Serial API][web-serial] | [Chrome 89](https://chromestatus.com/feature/6577673212002304) |
 | `sync-xhr` | [XMLHttpRequest][xhr] | [Chrome 65](https://www.chromestatus.com/feature/5154875084111872) |

--- a/features.md
+++ b/features.md
@@ -80,9 +80,9 @@ integrated into their respective specs.
 | `ch-prefers-reduced-transparency` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | `ch-prefers-contrast` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | `ch-prefers-forced-colors` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
-| Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
+| Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | See above |
 | `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
-| `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
+| `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | [Behind a flag in Firefox 92](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/speaker-selection) |
 
 ## Experimental Features
 

--- a/features.md
+++ b/features.md
@@ -22,7 +22,24 @@ specification.
 | `battery` | [Battery Status API][battery-status] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=1007264)" in Chrome |
 | `bluetooth` | [Web Bluetooth API][bluetooth] | [Chrome 104](https://chromestatus.com/feature/6439287120723968) |
 | `camera` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `ch-device-memory` | [Device Memory API][ch-device-memory] | [Chrome 61](https://chromestatus.com/feature/5741299856572416) |
+| `ch-downlink` | [Network Information API][ch-downlink] | [Chrome 69](https://chromestatus.com/feature/5407907378102272) |
+| `ch-dpr` | [Responsive Image Client Hints][ch-dpr] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
+| `ch-ect` | [Network Information API][ch-ect] | [Chrome 69](https://chromestatus.com/feature/5407907378102272) |
+| `ch-rtt` | [Network Information API][ch-rtt] | [Chrome 69](https://chromestatus.com/feature/5407907378102272) |
 | `ch-prefers-color-scheme` | [User Preference Media Features Client Hints Headers][ch-prefers-color-scheme] | [Chrome 93](https://chromestatus.com/feature/5642300464037888) |
+| `ch-save-data` | [Save Data API][ch-save-data] | [Chrome 102](https://chromestatus.com/feature/5645928215085056) |
+| `ch-ua` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-arch` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-bitness` | [User-Agent Client Hints][ch-ua-*] | [Chrome 93](https://chromestatus.com/feature/5733498725859328) |
+| `ch-ua-full-version-list` | [User-Agent Client Hints][ch-ua-*] | [Chrome 98](https://caniuse.com/mdn-http_headers_sec-ch-ua-full-version-list) |
+| `ch-ua-mobile` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-model` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-platform` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-platform-version` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-wow64` | [User-Agent Client Hints][ch-ua-*] | [Chrome 100](https://chromestatus.com/feature/5682026601512960) |
+| `ch-viewport-width` | [User-Agent Client Hints][ch-viewport-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
+| `ch-width` | [User-Agent Client Hints][ch-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
 | `cross-origin-isolated` | [HTML][html] | Experimental in Chrome 85 |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -75,6 +92,8 @@ experimentation by web developers.
 | ------------ | ------- | --------------- |
 | `attribution-reporting` | [Attribution Reporting API][attribution-reporting] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | In [Origin Trial](https://chromestatus.com/feature/5680923054964736) in Chrome 101-104 |
+| `ch-partitioned-cookies` | [CHIPS (Cookies Having Independent Partitioned State)](https://github.com/WICG/CHIPS) | In [Origin Trial](https://chromestatus.com/feature/5179189105786880) in Chrome 100-102 |
+| `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial]([https://chromestatus.com/feature/5179189105786880](https://chromestatus.com/feature/5646861215989760)) in Chrome 100-104 |
 | `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -102,7 +121,16 @@ names will be added to this list as they are actually defined.
 [attribution-reporting]: https://wicg.github.io/conversion-measurement-api/#permission-policy-integration
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
 [bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
+[ch-device-memory]: https://www.w3.org/TR/device-memory/
+[ch-downlink]: https://wicg.github.io/netinfo/#downlink-attribute
+[ch-dpr]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-dpr
+[ch-ect]:  https://wicg.github.io/netinfo/#ect-request-header-field
+[ch-rtt]: https://wicg.github.io/netinfo/#rtt-attribute
+[ch-save-data]: https://wicg.github.io/savedata/
+[ch-ua-*]: https://wicg.github.io/ua-client-hints/
 [ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features
+[ch-viewport-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width
+[ch-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-width
 [direct-sockets]: https://wicg.github.io/direct-sockets/#permissions-policy
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration

--- a/features.md
+++ b/features.md
@@ -35,7 +35,7 @@ specification.
 | `ch-ua-full-version-list` | [User-Agent Client Hints][ch-ua-*] | [Chrome 98](https://caniuse.com/mdn-http_headers_sec-ch-ua-full-version-list) |
 | `ch-ua-mobile` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-model` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
-| `ch-ua-platform` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
+| `ch-ua-platform` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `ch-ua-platform-version` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-wow64` | [User-Agent Client Hints][ch-ua-*] | [Chrome 100](https://chromestatus.com/feature/5682026601512960) |
 | `ch-viewport-width` | [User-Agent Client Hints][ch-viewport-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
@@ -48,6 +48,7 @@ specification.
 | `encrypted-media` | [Encrypted Media Extensions][encrypted-media] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `execution-while-not-rendered` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `execution-while-out-of-viewport` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
+| `focus-without-user-activation` | [HTML][focus-without-user-activation] | [Chrome 76](https://chromestatus.com/feature/5179186249465856) | 
 | `fullscreen` | [Fullscreen API][fullscreen] | [Chrome 62](https://www.chromestatus.com/feature/5094837900541952) |
 | `geolocation` | [Geolocation API][geolocation] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `gyroscope` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
@@ -134,6 +135,7 @@ names will be added to this list as they are actually defined.
 [clipboard]: https://w3c.github.io/clipboard-apis/#clipboard-permissions
 [direct-sockets]: https://wicg.github.io/direct-sockets/#permissions-policy
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
+[focus-without-user-activation]: https://github.com/whatwg/html/pull/4585
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy

--- a/features.md
+++ b/features.md
@@ -61,6 +61,7 @@ specification.
 | `microphone` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
+| `otp-credentials` | [WebOTP API][otp-credentials] | [Chrome 84](https://chromestatus.com/feature/5873577578463232) |
 | `payment` | [Payment Request API][payment-request] | [Chrome 62](https://chromestatus.com/feature/5639348045217792)] |
 | `picture-in-picture` | [Picture-in-Picture (PIP) API][pip] | [Chrome 72](https://chromestatus.com/feature/5729206566649856) |
 | `publickey-credentials-get` | [Web Authentication API][publickey-credentials-get] | [Chrome 70](https://chromestatus.com/feature/5669923372138496) |
@@ -162,6 +163,7 @@ names will be added to this list as they are actually defined.
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration
 [navigation-override]: https://drafts.csswg.org/css-nav-1/#policy-feature
+[otp-credentials]: https://wicg.github.io/web-otp/#otp-credentials-feature
 [page-lifecycle]: https://wicg.github.io/page-lifecycle/#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#permissions-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy

--- a/features.md
+++ b/features.md
@@ -32,7 +32,7 @@ specification.
 | `ch-ua` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-arch` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-bitness` | [User-Agent Client Hints][ch-ua-*] | [Chrome 93](https://chromestatus.com/feature/5733498725859328) |
-| `ch-ua-full-version-list` | [User-Agent Client Hints][ch-ua-*] | [Chrome 98](https://caniuse.com/mdn-http_headers_sec-ch-ua-full-version-list) |
+| `ch-ua-full-version-list` | [User-Agent Client Hints][ch-ua-*] | [Chrome 98](https://chromestatus.com/feature/5703317813460992) |
 | `ch-ua-mobile` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-model` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) |
 | `ch-ua-platform` | [User-Agent Client Hints][ch-ua-*] | [Chrome 89](https://chromestatus.com/feature/5995832180473856) Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -115,6 +115,7 @@ different feature name.
 
 | Feature name | Spec link(s) | Browser Support | Description |
 | ------------ | ------------ | --------------- | ----------- |
+| `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead. |
 | `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
 
 
@@ -144,6 +145,7 @@ names will be added to this list as they are actually defined.
 [ch-rtt]: https://wicg.github.io/netinfo/#rtt-attribute
 [ch-save-data]: https://wicg.github.io/savedata/
 [ch-ua-*]: https://wicg.github.io/ua-client-hints/
+[ch-ua-full-version]: https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version
 [ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features
 [ch-viewport-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width
 [ch-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-width

--- a/features.md
+++ b/features.md
@@ -56,6 +56,7 @@ specification.
 | `hid` | [WebHID API][webhid] | [Chrome 89](https://chromestatus.com/feature/5172464636133376) |
 | `idle-detection` | [Idle Detection API][idle-detection] | [Chrome 94](https://chromestatus.com/feature/4590256452009984) |
 | `keyboard-map` | [Keyboard Map API][keyboard-map] | [Chrome 97](https://chromestatus.com/feature/5657965899022336) |
+| `local-fonts` | [Local Font Access API][local-fonts-access] |  [Chrome 103](https://chromestatus.com/feature/6234451761692672) |
 | `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `microphone` |[Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
@@ -156,6 +157,7 @@ names will be added to this list as they are actually defined.
 [idle-detection]: https://wicg.github.io/idle-detection/#api-permissions-policy
 [interest-cohort]: https://wicg.github.io/floc/#permissions-policy-integration
 [join-ad-interest-group]: https://github.com/WICG/turtledove/blob/main/FLEDGE.md#11-joining-interest-groups
+[local-fonts-access]: https://wicg.github.io/local-font-access/#permissions-policy
 [keyboard-map]: https://wicg.github.io/keyboard-map/#permissions-policy
 [media-capture]: https://w3c.github.io/mediacapture-main/#permissions-policy-integration
 [media-capture-screen-share]: https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration

--- a/features.md
+++ b/features.md
@@ -100,7 +100,6 @@ experimentation by web developers.
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | In [Origin Trial](https://chromestatus.com/feature/5680923054964736) in Chrome 101-104 |
 | `ch-partitioned-cookies` | [CHIPS (Cookies Having Independent Partitioned State)](https://github.com/WICG/CHIPS) | In [Origin Trial](https://chromestatus.com/feature/5179189105786880) in Chrome 100-102 |
 | `ch-viewport-height` | [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) | In [Origin Trial](https://chromestatus.com/feature/5646861215989760) in Chrome 100-104 |
-| `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[5](#fn5)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
 | `join-ad-interest-group` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)][join-ad-interest-group] |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
@@ -116,6 +115,7 @@ different feature name.
 | Feature name | Spec link(s) | Browser Support | Description |
 | ------------ | ------------ | --------------- | ----------- |
 | `ch-ua-full-version` | [User-Agent Client Hints][ch-ua-full-version] | Shipped new name in [Chrome 98](https://chromestatus.com/feature/5703317813460992) | `ch-ua-full-version` is deprecated and will be removed in the future. Developers should use `ch-ua-full-version-list` instead. |
+| `conversion-measurement` | [Attribution Reporting API][conversion-measurement] | In [Origin Trial](https://chromestatus.com/feature/6412002824028160) in Chrome 101-104 | `conversion-measurement` has been renamed to `attribution-reporting` |
 | `interest-cohort` | [Federated Learning of Cohorts][interest-cohort] | In [Origin Trial](https://chromestatus.com/feature/5710139774468096) in Chrome 89 to undefined | This proposal has been replaced by the [Topics API](https://github.com/jkarlin/topics/). |
 
 
@@ -132,9 +132,6 @@ names will be added to this list as they are actually defined.
 <a name="fn4">[4]</a>: To enable this, use the Chrome command line flag
 `--enable-blink-features=Serial`.
 
-<a name="fn5">[5]</a>: To enable this, use the Chrome command line flag
-`--enable-blink-features=ConversionMeasurement`.
-
 [attribution-reporting]: https://wicg.github.io/conversion-measurement-api/#permission-policy-integration
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
 [bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
@@ -150,6 +147,7 @@ names will be added to this list as they are actually defined.
 [ch-viewport-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width
 [ch-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-width
 [clipboard]: https://w3c.github.io/clipboard-apis/#clipboard-permissions
+[conversion-measurement]: https://wicg.github.io/conversion-measurement-api/#permission-policy-integration
 [direct-sockets]: https://wicg.github.io/direct-sockets/#permissions-policy
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [focus-without-user-activation]: https://github.com/whatwg/html/pull/4585

--- a/features.md
+++ b/features.md
@@ -68,6 +68,7 @@ specification.
 | `serial` | [Web Serial API][web-serial] | [Chrome 89](https://chromestatus.com/feature/6577673212002304) |
 | `sync-xhr` | [XMLHttpRequest][xhr] | [Chrome 65](https://www.chromestatus.com/feature/5154875084111872) |
 | `usb` | [WebUSB][webusb] | [Chrome 61](https://chromestatus.com/feature/5651917954875392) |
+| `vertical-scroll` | [Vertical Scroll](policies/vertical_scroll.md) | [Chrome 88](https://caniuse.com/permissions-policy) |
 | `web-share` | [Web Share API][web-share] | Chrome 86 |
 | `xr-spatial-tracking`<sup>[2](#fn2)</sup> | [WebXR Device API][xr] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
 
@@ -104,7 +105,6 @@ experimentation by web developers.
 | `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Trust Token API](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://chromestatus.com/feature/5078049450098688) in Chrome 84-101 |
-| `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `window-placement` | [Explainer](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-8087339030850568191) in Chrome 93-96 |
 
 ## Deprecated Features

--- a/features.md
+++ b/features.md
@@ -40,6 +40,8 @@ specification.
 | `ch-ua-wow64` | [User-Agent Client Hints][ch-ua-*] | [Chrome 100](https://chromestatus.com/feature/5682026601512960) |
 | `ch-viewport-width` | [User-Agent Client Hints][ch-viewport-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
 | `ch-width` | [User-Agent Client Hints][ch-width] | [Chrome 46](https://chromestatus.com/feature/5504430086553600) |
+| `clipboard-read` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
+| `clipboard-write` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
 | `cross-origin-isolated` | [HTML][html] | Experimental in Chrome 85 |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
@@ -77,8 +79,6 @@ integrated into their respective specs.
 | `ch-prefers-contrast` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | `ch-prefers-forced-colors` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
-| `clipboard-read` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
-| `clipboard-write` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
 | `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
 | `gamepad` | https://github.com/w3c/gamepad/pull/112 |  |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
@@ -131,6 +131,7 @@ names will be added to this list as they are actually defined.
 [ch-prefers-color-scheme]: https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features
 [ch-viewport-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width
 [ch-width]: https://wicg.github.io/responsive-image-client-hints/#sec-ch-width
+[clipboard]: https://w3c.github.io/clipboard-apis/#clipboard-permissions
 [direct-sockets]: https://wicg.github.io/direct-sockets/#permissions-policy
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration

--- a/features.md
+++ b/features.md
@@ -71,7 +71,7 @@ specification.
 | `vertical-scroll` | [Vertical Scroll](policies/vertical_scroll.md) | [Chrome 88](https://caniuse.com/permissions-policy) |
 | `web-share` | [Web Share API][web-share] | [Chrome 86](https://chromestatus.com/feature/5668769141620736) |
 | `window-placement` | [Multi-Screen Window Placement on the Web API][window-placement] | [Chrome 103](https://chromestatus.com/feature/5173162437246976) |
-| `xr-spatial-tracking`<sup>[2](#fn2)</sup> | [WebXR Device API][xr] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
+| `xr-spatial-tracking` | [WebXR Device API][xr] | [Chrome 79](https://chromestatus.com/feature/5680169905815552) |
 
 ## Proposed Features
 

--- a/features.md
+++ b/features.md
@@ -50,6 +50,7 @@ specification.
 | `execution-while-out-of-viewport` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `focus-without-user-activation` | [HTML][focus-without-user-activation] | [Chrome 76](https://chromestatus.com/feature/5179186249465856) | 
 | `fullscreen` | [Fullscreen API][fullscreen] | [Chrome 62](https://www.chromestatus.com/feature/5094837900541952) |
+| `gamepad` | [Gamepad API][gamepad] | [Chrome 86](https://chromestatus.com/feature/5138714634223616) |
 | `geolocation` | [Geolocation API][geolocation] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `gyroscope` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `hid` | [WebHID API][webhid] | [Chrome 89](https://chromestatus.com/feature/5172464636133376) |
@@ -81,7 +82,6 @@ integrated into their respective specs.
 | `ch-prefers-forced-colors` | https://wicg.github.io/user-preference-media-features-headers/#policy-controlled-features |  |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
 | `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
-| `gamepad` | https://github.com/w3c/gamepad/pull/112 |  |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
 
 ## Experimental Features
@@ -137,6 +137,7 @@ names will be added to this list as they are actually defined.
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
 [focus-without-user-activation]: https://github.com/whatwg/html/pull/4585
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration
+[gamepad]: https://www.w3.org/TR/gamepad/#permission-policy
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features

--- a/features.md
+++ b/features.md
@@ -70,6 +70,7 @@ specification.
 | `usb` | [WebUSB][webusb] | [Chrome 61](https://chromestatus.com/feature/5651917954875392) |
 | `vertical-scroll` | [Vertical Scroll](policies/vertical_scroll.md) | [Chrome 88](https://caniuse.com/permissions-policy) |
 | `web-share` | [Web Share API][web-share] | [Chrome 86](https://chromestatus.com/feature/5668769141620736) |
+| `window-placement` | [Multi-Screen Window Placement on the Web API][window-placement] | [Chrome 103](https://chromestatus.com/feature/5173162437246976) |
 | `xr-spatial-tracking`<sup>[2](#fn2)</sup> | [WebXR Device API][xr] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
 
 ## Proposed Features
@@ -105,7 +106,6 @@ experimentation by web developers.
 | `run-ad-auction` | [First "Locally-Executed Decision over Groups" Experiment (FLEDGE)](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction) |  In [Origin Trial](https://chromestatus.com/feature/5733583115255808) in Chrome 101-104 |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Trust Token API](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://chromestatus.com/feature/5078049450098688) in Chrome 84-101 |
-| `window-placement` | [Explainer](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-8087339030850568191) in Chrome 93-96 |
 
 ## Deprecated Features
 
@@ -175,5 +175,6 @@ names will be added to this list as they are actually defined.
 [web-share]: https://w3c.github.io/web-share/#permissions-policy
 [webhid]: https://wicg.github.io/webhid/#permissions-policy
 [webusb]: https://wicg.github.io/webusb/#permissions-policy
+[window-placement]: https://github.com/w3c/window-placement/blob/main/EXPLAINER.md
 [xhr]: https://xhr.spec.whatwg.org/#feature-policy-integration
 [xr]: https://immersive-web.github.io/webxr/#permissions-policy

--- a/features.md
+++ b/features.md
@@ -43,7 +43,7 @@ specification.
 | `clipboard-read` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
 | `clipboard-write` | [Clipboard API and events][clipboard] | [Chrome 85](https://chromestatus.com/feature/57670752953958400) |
 | `cross-origin-isolated` | [HTML][html] | [Chrome 87](https://chromestatus.com/feature/5690888397258752) |
-| `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
+| `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | [Chrome 94](https://chromestatus.com/feature/5144822362931200) |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `encrypted-media` | [Encrypted Media Extensions][encrypted-media] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `execution-while-not-rendered` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |

--- a/features.md
+++ b/features.md
@@ -88,6 +88,7 @@ integrated into their respective specs.
 | `direct-sockets` | https://wicg.github.io/direct-sockets/#permissions-policy | |
 | `navigation-override` | [CSS Spatial Navigation][navigation-override] |  |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | [Behind a flag in Firefox 92](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/speaker-selection) |
+| `storage-access-api` / `request-storage-access` | [The Storage Access API][storage-access-api] | [Pending adding to Chrome](https://chromestatus.com/feature/5612590694662144) |
 
 ## Experimental Features
 
@@ -172,6 +173,7 @@ names will be added to this list as they are actually defined.
 [payment-request]: https://www.w3.org/TR/payment-request/#permissions-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy
 [publickey-credentials-get]: https://w3c.github.io/webauthn/#sctn-permissions-policy
+[storage-access-api]: https://privacycg.github.io/storage-access/#permissions-policy-integration
 [sync-script]: https://github.com/WICG/document-policy/issues/2
 [wake-lock]: https://w3c.github.io/screen-wake-lock/#policy-control
 [web-midi]: https://webaudio.github.io/web-midi-api/#permissions-policy-integration


### PR DESCRIPTION
Github issue: https://github.com/w3c/webappsec-permissions-policy/issues/471

Have updated the `features.md` file as it was very out of date!

### Deprecated Features

Added a `Deprecated Features` section, features that were added to a browser and are still listed in the browsers source code, but have since been deprecated or replaced with a different feature name.

### Behind a flag (Chromium)

As of May 2002, see here: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/permissions_policy/permissions_policy_features.json5

- `ch-ua-platform`
- `join-ad-interest-group`
- `run-ad-auction`

Are behind flags according to the Chromium source code and so updating the doc's accordingly.
