### PR TITLE
Editorial: export * and 'self'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -315,11 +315,11 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
-      <dt><dfn export><code>*</code></dfn></dt>
+      <dt><dfn for="default allowlist" export><code>*</code></dfn></dt>
       <dd>The feature is allowed in documents in top-level browsing contexts by
       default, and when allowed, is allowed by default to documents in child
       browsing contexts.</dd>
-      <dt><dnf export><code>'self'</code></dfn></dt>
+      <dt><dfn for="default allowlist" export><code>'self'</code></dfn></dt>
       <dd>The feature is allowed in documents in top-level browsing contexts by
       default, and when allowed, is allowed by default to same-origin domain
       documents in child browsing contexts, but is disallowed by default in

--- a/index.bs
+++ b/index.bs
@@ -315,11 +315,11 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
-      <dt><code>*</code></dt>
+      <dt><dfn export><code>*</code></dfn></dt>
       <dd>The feature is allowed in documents in top-level browsing contexts by
       default, and when allowed, is allowed by default to documents in child
       browsing contexts.</dd>
-      <dt><code>'self'</code></dt>
+      <dt><dnf export><code>'self'</code></dfn></dt>
       <dd>The feature is allowed in documents in top-level browsing contexts by
       default, and when allowed, is allowed by default to same-origin domain
       documents in child browsing contexts, but is disallowed by default in


### PR DESCRIPTION
Exporting these will allow other specs to link to these definitions. 