### PR TITLE
Update "Is feature enabled in document for origin?" behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -946,7 +946,7 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="is-feature-enabled">
     Given a feature (|feature|), a {{Document}} object
-    (|document|), an [=origin=] (|origin|), and a boolean isEquivalentOptInFeatureExistAndEnabled, this algorithm
+    (|document|), an [=origin=] (|origin|), and a boolean (|isEquivalentOptInFeatureExistAndEnabled|), this algorithm
     returns "<code>Disabled</code>" if |feature| should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
     1. Let |policy| be |document|'s <a>Permissions Policy</a>
@@ -1024,7 +1024,7 @@ partial interface HTMLIFrameElement {
        sending Client Hints to third parties) in these contexts.</div>
     1. Set |document| to |window|’s <a>associated `Document`</a>.
     1. Let |origin| be |request|’s <a for="request">origin</a>.
-    1. Let |isEquivalentOptInFeatureExistAndEnabled| be false.
+    1. Let |isEquivalentOptInFeatureExistAndEnabled| be |false|.
     1. If |request| contains an equivalent opt-in flag for |feature|, and if the opt-in flag's state is |true| (i.e. allowed),  then set |isEquivalentOptInFeatureExistAndEnabled| to |true|.
     1. Let |result| be the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |document|, |origin|, and |isEquivalentOptInFeatureExistAndEnabled|.

--- a/index.bs
+++ b/index.bs
@@ -946,7 +946,7 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="is-feature-enabled">
     Given a feature (|feature|), a {{Document}} object
-    (|document|), and an [=origin=] (|origin|), this algorithm
+    (|document|), an [=origin=] (|origin|), and a boolean isEquivalentOptInFeatureExistAndEnabled, this algorithm
     returns "<code>Disabled</code>" if |feature| should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
     1. Let |policy| be |document|'s <a>Permissions Policy</a>
@@ -957,6 +957,7 @@ partial interface HTMLIFrameElement {
           policy</a> <a>matches</a> |origin|, then return
           "<code>Enabled</code>".
         1. Otherwise return "<code>Disabled</code>".
+    1. If |isEquivalentOptInFeatureExistAndEnabled| is |true|, then return "<code>Enabled</code>".
     1. If |feature|'s <a>default allowlist</a> is <code>*</code>, return
       "<code>Enabled</code>".
     1. If |feature|'s <a>default allowlist</a> is <code>'self'</code>, and
@@ -1023,8 +1024,10 @@ partial interface HTMLIFrameElement {
        sending Client Hints to third parties) in these contexts.</div>
     1. Set |document| to |window|’s <a>associated `Document`</a>.
     1. Let |origin| be |request|’s <a for="request">origin</a>.
+    1. Let |isEquivalentOptInFeatureExistAndEnabled| be false.
+    1. If |request| contains an equivalent opt-in flag for |feature|, and if the opt-in flag's state is |true| (i.e. allowed),  then set |isEquivalentOptInFeatureExistAndEnabled| to |true|.
     1. Let |result| be the result of executing <a abstract-op>Is feature
-      enabled in document for origin?</a> on |feature|, |document|, and |origin|.
+      enabled in document for origin?</a> on |feature|, |document|, |origin|, and |isEquivalentOptInFeatureExistAndEnabled|.
     1. If |result| is "<code>Enabled</code>", return <code>true</code>.
     1. Otherwise, return <code>false</code>.
 


### PR DESCRIPTION
Rationale: if a page can create an <iframe src=… allow="featureX"> and can delegate permissions to the iframe, then the request like fetch(url, {allowFeatureX: true}) should be allowed for the permission as well, otherwise, they can just create an iframe similarly to gain the permission.

For a feature that does not have an equivalent opt-in flag, this rationale isn’t 100% applicable, so I’ll leave the spec unchanged for now. But for feature that does have it (e.g. fetch(url, {browsingTopics: true}) for the [Topics API](https://github.com/patcg-individual-drafts/topics)), we should be able to skip the last few steps that check the default allowlist, and can return "Enabled" directly. This way, the behavior will be the same with the [Define an inherited policy for feature in container at origin](https://www.w3.org/TR/permissions-policy/#algo-define-inherited-policy-in-container) algorithm with a "*" container policy.