### PR TITLE
Fix `Define an inherited policy for feature in container at origin`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -920,13 +920,14 @@ partial interface HTMLIFrameElement {
     (|origin|), this algorithm returns the <a>inherited policy</a> for that
     feature.
     1. Let |policy| be |container|'s <a>node document</a>'s <a>Permissions
-      Policy</a>
+      Policy</a>.
+    1. If the result of executing <a abstract-op>Is feature
+      enabled in document for origin?</a> on |feature|, |container|'s <a>node document</a>',
+      and |container|'s <a>node document</a>''s |origin| is  "<code>Disabled</code>",
+      return "<code>Disabled</code>".
     1. If the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |container|'s <a>node document</a>',
       and |origin| is  "<code>Disabled</code>", return "<code>Disabled</code>".
-    1. If |feature| is present in |policy|'s <a>declared policy</a>, and the
-      <a>allowlist</a> for |feature| in |policy|'s <a>declared policy</a> does
-      not <a>match</a> |origin|, then return "<code>Disabled</code>".
     1. Let |container policy| be the result of running <a abstract-op>Process
       permissions policy attributes</a> on |container|.
     1. If |feature| is a key in |container policy|:

--- a/index.bs
+++ b/index.bs
@@ -921,8 +921,9 @@ partial interface HTMLIFrameElement {
     feature.
     1. Let |policy| be |container|'s <a>node document</a>'s <a>Permissions
       Policy</a>
-    1. If |policy|'s <a>inherited policy</a> for |feature| is
-      "<code>Disabled</code>", return "<code>Disabled</code>".
+    1. If the result of executing <a abstract-op>Is feature
+      enabled in document for origin?</a> on |feature|, |container|'s <a>node document</a>',
+      and |origin| is  "<code>Disabled</code>", return "<code>Disabled</code>".
     1. If |feature| is present in |policy|'s <a>declared policy</a>, and the
       <a>allowlist</a> for |feature| in |policy|'s <a>declared policy</a> does
       not <a>match</a> |origin|, then return "<code>Disabled</code>".

--- a/index.bs
+++ b/index.bs
@@ -922,12 +922,13 @@ partial interface HTMLIFrameElement {
     1. Let |policy| be |container|'s <a>node document</a>'s <a>Permissions
       Policy</a>.
     1. If the result of executing <a abstract-op>Is feature
-      enabled in document for origin?</a> on |feature|, |container|'s <a>node document</a>',
-      and |container|'s <a>node document</a>''s |origin| is  "<code>Disabled</code>",
-      return "<code>Disabled</code>".
+      enabled in document for origin?</a> on |feature|, |container|'s
+      <a>node document</a>, and |container|'s <a>node document</a>''s origin
+      is "<code>Disabled</code>", return "<code>Disabled</code>".
     1. If the result of executing <a abstract-op>Is feature
-      enabled in document for origin?</a> on |feature|, |container|'s <a>node document</a>',
-      and |origin| is  "<code>Disabled</code>", return "<code>Disabled</code>".
+      enabled in document for origin?</a> on |feature|, |container|'s
+      <a>node document</a>, and |origin| is "<code>Disabled</code>",
+      return "<code>Disabled</code>".
     1. Let |container policy| be the result of running <a abstract-op>Process
       permissions policy attributes</a> on |container|.
     1. If |feature| is a key in |container policy|:


### PR DESCRIPTION
The text implies only the inherited policy of the document should
be checked, but even if the containing document has the feature
enabled the document could set a permissions policy that denied access
to the specific origin. We must check the actual policy for the
containing document to know. Chrome is already doing this.

We can accomplish this by adapting both 9.8.2 and 9.8.3 to
use `Is feature enabled in document for origin?` but have the
first check the parent origin and the second check the
actual origin.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arichiv/webappsec-permissions-policy/pull/501.html" title="Last updated on Dec 20, 2022, 3:04 PM UTC (5247072)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/501/b44d905...arichiv:5247072.html" title="Last updated on Dec 20, 2022, 3:04 PM UTC (5247072)">Diff</a>