### PR TITLE
Update for new navigable concepts.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,8 @@ spec:dom; type:interface; for:/; text:Document
 spec:url; type:dfn; for:url; text:origin
 spec:fetch; type:dfn; for:Response; text:response
 spec:html; type:dfn; for:/; text:browsing context
+spec:html; type:dfn; for:/; text:navigable container
+spec:html; type:dfn; for:/; text:nested navigable
 spec:html; type:element; text:script
 spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
@@ -226,11 +228,11 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     each feature, and whether it can be controlled by a <a>declared policy</a>
     in the document.
     </p>
-    <p>In a {{Document}} in a [=top-level browsing context=], the inherited
+    <p>In a {{Document}} in a [=/top-level traversable=], the inherited
     policy is based on defined defaults for each feature.</p>
-    <p>In a {{Document}} in a [=child browsing context=], the inherited policy
-    is based on the parent document's permissions policy, as well as the [=child
-    browsing context=]'s <a>container policy</a>.
+    <p>In a {{Document}} in a [=child navigable=], the inherited policy is based
+    on the parent document's permissions policy, as well as the [=child
+    navigable=]'s <a>container policy</a>.
     </div>
   </section>
   <section>
@@ -248,12 +250,12 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
   </section>
   <section>
     <h3 id="container-policies">Container policies</h3>
-    <p>In addition to the <a>header policy</a>, each [=nested browsing context=]
-    has a <dfn export>container policy</dfn>, which is a <a>policy directive</a>,
+    <p>In addition to the <a>header policy</a>, each [=nested navigable=] has a
+    <dfn export>container policy</dfn>, which is a <a>policy directive</a>,
     which may be empty. The <a>container policy</a> can set by attributes on the
-    [=browsing context container=].</p>
-    <p>The <a>container policy</a> for a [=nested browsing context=] influences
-    the <a>inherited policy</a> of any document loaded into that context.
+    [=navigable container=].</p>
+    <p>The <a>container policy</a> for a [=nested navigable=] influences the
+    <a>inherited policy</a> of any document loaded into that context.
     (See <a href="#algo-define-inherited-policy"></a>)</p>
     <div class="note">
       Currently, the <a>container policy</a> cannot be set directly, but is
@@ -310,21 +312,21 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <p>Every <a>policy-controlled feature</a> has a <dfn export lt=
     "default allowlist|default allowlists" for="policy-controlled feature">default allowlist</dfn>.
     The <a>default allowlist</a> determines whether the feature is allowed in a
-    document with no declared policy in a top-level browsing context, and also
+    document with no declared policy in a [=/top-level traversable=], and also
     whether access to the feature is automatically delegated to documents in
-    child browsing contexts.</p>
+    [=child navigables=].</p>
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
       <dt><dfn for="default allowlist" export><code>*</code></dfn></dt>
-      <dd>The feature is allowed in documents in top-level browsing contexts by
+      <dd>The feature is allowed in documents in top-level traversables by
       default, and when allowed, is allowed by default to documents in child
-      browsing contexts.</dd>
+      navigables.</dd>
       <dt><dfn for="default allowlist" export><code>'self'</code></dfn></dt>
-      <dd>The feature is allowed in documents in top-level browsing contexts by
+      <dd>The feature is allowed in documents in top-level traversables by
       default, and when allowed, is allowed by default to same-origin domain
-      documents in child browsing contexts, but is disallowed by default in
-      cross-origin documents in child browsing contexts.</dd>
+      documents in child navigables, but is disallowed by default in
+      cross-origin documents in child navigables.</dd>
     </dl>
   </section>
 </section>
@@ -409,7 +411,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <p>When not empty, the "<code>allow</code>" attribute will result in adding
     an <a>allowlist</a> for each recognized
     <a data-lt="policy-controlled feature">feature</a> to the <{iframe}>
-    element's [=nested browsing context=]'s <a>container policy</a>, when it is
+    element's [=nested navigable=]'s <a>container policy</a>, when it is
     constructed.</p>
   </section>
   <section>
@@ -429,7 +431,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <p>Otherwise, the presence of an "<code>allowfullscreen</code>" attribute
       on an iframe will result in adding an <a>allowlist</a> of <code>*</code>
       for the "<code>fullscreen</code>" feature to the <{iframe}> element's
-      [=nested browsing context=]'s <a>container policy</a>, when it is
+      [=nested navigable=]'s <a>container policy</a>, when it is
       constructed.</p>
       <div class="note">
         This is different from the behaviour of <code>&lt;iframe
@@ -505,8 +507,8 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
   a feature is actually currently allowed in the frame, as the document in the
   frame may have applied its own policy via an HTTP header, or may have
   navigated away from its initial location to a new origin. Revealing the
-  effective policy in the iframe element's nested browsing context in that case
-  could leak information about the behaviour of a cross-origin document.</p>
+  effective policy in the iframe element's nested navigable in that case could
+  leak information about the behaviour of a cross-origin document.</p>
 
   <div class="example">
   <pre>
@@ -902,10 +904,10 @@ partial interface HTMLIFrameElement {
     Given a feature (|feature|), an <a>origin</a> (|origin|), and a <a>browsing
     context</a> (|browsingContext|), this algorithm returns the <a>inherited
     policy</a> for that feature.
-    1. If |browsingContext| is the [=nested browsing context=] of a [=browsing
-      context container=], return the result of executing <a abstract-op>Define
-      an inherited policy for feature in container at origin</a> for |feature|
-      in |browsingContext|'s <a>browsing context container</a> at |origin|.
+    1. If |browsingContext| is the [=nested navigable=] of a [=navigable
+      container=], return the result of executing <a abstract-op>Define an
+      inherited policy for feature in container at origin</a> for |feature|
+      in |browsingContext|'s <a>navigable container</a> at |origin|.
     1. Otherwise, return "<code>Enabled</code>".
 
     </div>
@@ -915,10 +917,9 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm"
     data-algorithm="define-inherited-policy-in-container">
-    Given a feature (|feature|) a <a>browsing context container</a>
-    (|container|), and an <a>origin</a> for a document in that container
-    (|origin|), this algorithm returns the <a>inherited policy</a> for that
-    feature.
+    Given a feature (|feature|), a <a>navigable container</a> (|container|), and
+    an <a>origin</a> for a document in that container (|origin|), this algorithm
+    returns the <a>inherited policy</a> for that feature.
     1. If the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |container|'s
       <a>node document</a>, and |container|'s <a>node document</a>''s origin

--- a/index.bs
+++ b/index.bs
@@ -16,9 +16,6 @@ Markup Shorthands: css no, markdown yes
 spec:dom; type:interface; for:/; text:Document
 spec:url; type:dfn; for:url; text:origin
 spec:fetch; type:dfn; for:Response; text:response
-spec:html; type:dfn; for:/; text:browsing context
-spec:html; type:dfn; for:/; text:navigable container
-spec:html; type:dfn; for:/; text:nested navigable
 spec:html; type:element; text:script
 spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
@@ -182,8 +179,8 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     character strings used in <a>policy directives</a>.
     <p>Each <a>policy-controlled feature</a> has a <a>default allowlist</a>,
     which defines whether that feature is available in documents in top-level
-    browsing contexts, and how access to that feature is inherited in child
-    browsing contexts.</p>
+    traversables, and how access to that feature is inherited in child
+    navigables.</p>
     <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
     of <a data-lt="policy-controlled feature">features</a> which it allows to be
     controlled through policies. User agents are not required to support every
@@ -250,13 +247,13 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
   </section>
   <section>
     <h3 id="container-policies">Container policies</h3>
-    <p>In addition to the <a>header policy</a>, each [=nested navigable=] has a
+    <p>In addition to the <a>header policy</a>, each [=child navigable=] has a
     <dfn export>container policy</dfn>, which is a <a>policy directive</a>,
     which may be empty. The <a>container policy</a> can set by attributes on the
     [=navigable container=].</p>
-    <p>The <a>container policy</a> for a [=nested navigable=] influences the
-    <a>inherited policy</a> of any document loaded into that context.
-    (See <a href="#algo-define-inherited-policy"></a>)</p>
+    <p>The <a>container policy</a> for a [=child navigable=] influences the
+    <a>inherited policy</a> of any document loaded into that navigable.
+    (See <a href="#algo-define-inherited-policy-in-container"></a>)</p>
     <div class="note">
       Currently, the <a>container policy</a> cannot be set directly, but is
       indirectly set by <code>iframe</code> "<a href=
@@ -309,12 +306,13 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
   </section>
   <section>
     <h3 id="default-allowlists">Default Allowlists</h3>
-    <p>Every <a>policy-controlled feature</a> has a <dfn export lt=
-    "default allowlist|default allowlists" for="policy-controlled feature">default allowlist</dfn>.
-    The <a>default allowlist</a> determines whether the feature is allowed in a
-    document with no declared policy in a [=/top-level traversable=], and also
-    whether access to the feature is automatically delegated to documents in
-    [=child navigables=].</p>
+    <p>Every <a>policy-controlled feature</a> has a <dfn export
+    lt="default allowlist|default allowlists"
+    for="policy-controlled feature">default allowlist</dfn>. The <a>default
+    allowlist</a> determines whether the feature is allowed in a document with
+    no declared policy in a [=/top-level traversable=], and also whether access
+    to the feature is automatically delegated to documents in [=child
+    navigables=].</p>
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
@@ -411,8 +409,8 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
     <p>When not empty, the "<code>allow</code>" attribute will result in adding
     an <a>allowlist</a> for each recognized
     <a data-lt="policy-controlled feature">feature</a> to the <{iframe}>
-    element's [=nested navigable=]'s <a>container policy</a>, when it is
-    constructed.</p>
+    element's [=navigable container/content navigable=]'s <a>container
+    policy</a>, when it is constructed.</p>
   </section>
   <section>
     <h3 id="legacy-attributes">Additional attributes to support legacy
@@ -431,8 +429,8 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <p>Otherwise, the presence of an "<code>allowfullscreen</code>" attribute
       on an iframe will result in adding an <a>allowlist</a> of <code>*</code>
       for the "<code>fullscreen</code>" feature to the <{iframe}> element's
-      [=nested navigable=]'s <a>container policy</a>, when it is
-      constructed.</p>
+      [=navigable container/content navigable=]'s <a>container policy</a>, when
+      it is constructed.</p>
       <div class="note">
         This is different from the behaviour of <code>&lt;iframe
         allow="fullscreen"&gt;</code>, and is for compatibility with existing
@@ -639,9 +637,8 @@ partial interface HTMLIFrameElement {
     8. Return |result|.
 
     <p>The <dfn>observable policy</dfn> for any Node is a <a>permissions
-    policy</a>, which contains the information about the policy in the browsing
-    context represented by that Node which is visible from the current browsing
-    context.</p>
+    policy</a>, which contains the information about the policy in the navigable
+    represented by that Node which is visible from the current document.</p>
 
     <p>To get the <a>observable policy</a> for a Document |document|, return
     |document|'s permissions policy.</p>
@@ -650,9 +647,9 @@ partial interface HTMLIFrameElement {
         1. Let |inherited policy| be a new ordered map.
         2. Let |declared policy| be a new ordered map.
         3. For each <a>supported feature</a> |feature|:
-            1. Let |isInherited| be the result of running <a abstract-op>Define an
-                inherited policy for feature in container at origin</a> on |feature|,
-                |node| and |node|'s <a>declared origin</a>.
+            1. Let |isInherited| be the result of running <a abstract-op>Define
+                an inherited policy for feature in container at origin</a> on
+                |feature|, |node| and |node|'s <a>declared origin</a>.
             2. Set |inherited policy|[|feature|] to |isInherited|.
         4. Return a new <a>permissions policy</a> with inherited policy
             |inherited policy| and declared policy |declared policy|.
@@ -861,33 +858,36 @@ partial interface HTMLIFrameElement {
     </div>
   </section>
   <section>
-    ## <dfn export abstract-op id="create-for-browsingcontext">Create a Permissions Policy for a browsing context</dfn> ## {#algo-create-for-browsingcontext}
+    ## <dfn export abstract-op id="create-for-navigable">Create a Permissions Policy for a navigable</dfn> ## {#algo-create-for-navigable}
 
-    <div class="algorithm" data-algorithm="create-for-browsingcontext">
-    Given a <a>browsing context</a> (|browsingContext|), and an <a>origin</a>
+    <div class="algorithm" data-algorithm="create-for-navigable">
+    Given null or an <a for="/">element</a> (|container|) and an <a>origin</a>
     (|origin|) this algorithm returns a new <a>Permissions Policy</a>.
+    1. Assert: If not null, |container| is a <a>navigable container</a>.
     1. Let |inherited policy| be a new ordered map.
     1. Let |declared policy| be a new ordered map.
     1. For each |feature| supported,
         1. Let |isInherited| be the result of running <a abstract-op>Define an
-          inherited policy for feature in browsing context</a> on |feature|,
-          |origin| and |browsingContext|.
+          inherited policy for feature in container at origin</a> on |feature|,
+          |container| and |origin|.
         1. Set |inherited policy|[|feature|] to |isInherited|.
     1. Let |policy| be a new <a>permissions policy</a>, with inherited policy
       |inherited policy| and declared policy |declared policy|.
     1. Return |policy|.
 
+    Note: HTML should be updated to call this algorithm from "create a new
+    browsing context and document".
     </div>
   </section>
   <section>
-    ## <dfn export abstract-op id="create-from-response">Create a Permissions Policy for a browsing context from response</dfn> ## {#algo-create-from-response}
+    ## <dfn export abstract-op id="create-from-response">Create a Permissions Policy for a navigable from response</dfn> ## {#algo-create-from-response}
 
     <div class="algorithm" data-algorithm="create-from-response">
-    Given a <a>browsing context</a> (|browsingContext|), <a>origin</a>
+    Given null or a <a>navigable container</a> (|container|), an <a>origin</a>
     (|origin|), and a [=response=] (|response|), this algorithm returns a new
     <a>Permissions Policy</a>.
     1. Let |policy| be the result of running <a abstract-op>Create a Permissions
-      Policy for a browsing context</a> given |browsingContext|, and |origin|.
+      Policy for a navigable</a> given |container| and |origin|.
     1. Let |d| be the result of running <a abstract-op>Process response
       policy</a> on |response| and |origin|.
     1. For each |feature| → |allowlist| of |d|:
@@ -898,28 +898,15 @@ partial interface HTMLIFrameElement {
     </div>
   </section>
   <section>
-    ## <dfn export abstract-op id="define-inherited-policy">Define an inherited policy for feature in browsing context</dfn> ## {#algo-define-inherited-policy}
-
-    <div class="algorithm" data-algorithm="define-inherited-policy">
-    Given a feature (|feature|), an <a>origin</a> (|origin|), and a <a>browsing
-    context</a> (|browsingContext|), this algorithm returns the <a>inherited
-    policy</a> for that feature.
-    1. If |browsingContext| is the [=nested navigable=] of a [=navigable
-      container=], return the result of executing <a abstract-op>Define an
-      inherited policy for feature in container at origin</a> for |feature|
-      in |browsingContext|'s <a>navigable container</a> at |origin|.
-    1. Otherwise, return "<code>Enabled</code>".
-
-    </div>
-  </section>
-  <section>
     ## <dfn export abstract-op id="define-inherited-policy-in-container">Define an inherited policy for feature in container at origin</dfn> ## {#algo-define-inherited-policy-in-container}
 
     <div class="algorithm"
     data-algorithm="define-inherited-policy-in-container">
-    Given a feature (|feature|), a <a>navigable container</a> (|container|), and
-    an <a>origin</a> for a document in that container (|origin|), this algorithm
-    returns the <a>inherited policy</a> for that feature.
+    Given a feature (|feature|), null or a <a>navigable container</a>
+    (|container|), and an <a>origin</a> for a document in that container
+    (|origin|), this algorithm returns the <a>inherited policy</a> for that
+    feature.
+    1. If |container| is null, return "<code>Enabled</code>".
     1. If the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |container|'s
       <a>node document</a>, and |container|'s <a>node document</a>''s origin

--- a/index.bs
+++ b/index.bs
@@ -114,11 +114,11 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
   </div>
   <div class="example">
     <p>SecureCorp Inc. wants to completely disable use of the Geolocation API
-    within all browsing contexts except for its own origin and those whose
-    origin is "<code>https://example.com</code>", even in the presence of an
-    attacker who can embed their own iframes on SecureCorp's pages. It can do
-    this by delivering the following HTTP response header to define a restricted
-    permissions policy for Geolocation:</p>
+    within all [=Document/descendant navigables=] except for its own origin and
+    those whose origin is "<code>https://example.com</code>", even in the
+    presence of an attacker who can embed their own iframes on SecureCorp's
+    pages. It can do this by delivering the following HTTP response header to
+    define a restricted permissions policy for Geolocation:</p>
     <pre>
       <a http-header>Permissions-Policy</a>: geolocation=(self "https://example.com")</pre>
     <p>The <a>allowlist</a> is a list of one or more origins, which can include
@@ -875,8 +875,6 @@ partial interface HTMLIFrameElement {
       |inherited policy| and declared policy |declared policy|.
     1. Return |policy|.
 
-    Note: HTML should be updated to call this algorithm from "create a new
-    browsing context and document".
     </div>
   </section>
   <section>


### PR DESCRIPTION
The browsing context container and nested browsing context concepts, used by the algorithms here, have been replaced in HTML with navigables and traversibles. Updates the spec to use those concepts instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/pull/505.html" title="Last updated on Jan 23, 2023, 5:30 AM UTC (99edaab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/505/f909827...99edaab.html" title="Last updated on Jan 23, 2023, 5:30 AM UTC (99edaab)">Diff</a>