### PR TITLE
Fix typo double-apostrophe

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -911,7 +911,7 @@ partial interface HTMLIFrameElement {
     1. If |container| is null, return "<code>Enabled</code>".
     1. If the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |container|'s
-      <a>node document</a>, and |container|'s <a>node document</a>''s origin
+      <a>node document</a>, and |container|'s <a>node document</a>'s origin
       is "<code>Disabled</code>", return "<code>Disabled</code>".
     1. If the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |container|'s


### PR DESCRIPTION
Just a minor typo I happened to spot.

@clelland


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fergald/webappsec-permissions-policy/pull/514.html" title="Last updated on May 24, 2023, 9:19 AM UTC (eea2186)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/514/ba7927a...fergald:eea2186.html" title="Last updated on May 24, 2023, 9:19 AM UTC (eea2186)">Diff</a>