### PR TITLE
Fix "Define an inherited policy for feature in container at origin" algo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -909,14 +909,13 @@ partial interface HTMLIFrameElement {
     that container (|origin|), this algorithm returns the [=inherited policy for
     a feature|inherited policy value=] for |feature|.
     1. If |container| is null, return "<code>Enabled</code>".
-    1. If the result of executing <a abstract-op>Is feature
-      enabled in document for origin?</a> on |feature|, |container|'s
-      <a>node document</a>, and |container|'s <a>node document</a>'s origin
-      is "<code>Disabled</code>", return "<code>Disabled</code>".
-    1. If the result of executing <a abstract-op>Is feature
-      enabled in document for origin?</a> on |feature|, |container|'s
-      <a>node document</a>, and |origin| is "<code>Disabled</code>",
-      return "<code>Disabled</code>".
+    1. If the result of executing <a abstract-op>Get feature value for
+      origin</a> on |feature|, |container|'s <a>node document</a>, and
+      |container|'s <a>node document</a>'s origin is
+      "<code>Disabled</code>", return "<code>Disabled</code>".
+    1. If the result of executing <a abstract-op>Get feature value for
+      origin</a> on |feature|, |container|'s <a>node document</a>, and
+      |origin| is "<code>Disabled</code>", return "<code>Disabled</code>".
     1. Let |container policy| be the result of running <a abstract-op>Process
       permissions policy attributes</a> on |container|.
     1. If |feature| [=map/exists=] in |container policy|:
@@ -929,6 +928,27 @@ partial interface HTMLIFrameElement {
       |origin| is [=same origin=] with |container|'s <a>node document</a>'s
       [=Document/origin=], return "<code>Enabled</code>".
     1. Otherwise return "<code>Disabled</code>".
+
+    </div>
+  </section>
+  <section>
+    ## <dfn export abstract-op id="get-feature-value-for-origin">Get feature value for origin</dfn> ## {#algo-get-feature-value-for-origin}
+
+    <div class="algorithm" data-algorithm="get-feature-value-for-origin">
+    Given a [=feature=] (|feature|), a {{Document}} object
+    (|document|), and an [=origin=] (|origin|), this algorithm
+    returns "<code>Disabled</code>" if |feature| should be considered
+    disabled, and "<code>Enabled</code>" otherwise.</p>
+    1. Let |policy| be |document|'s [=Document/permissions policy=].
+    1. If |policy|'s <a for="permissions policy">inherited policy</a> for
+       |feature| is "<code>Disabled</code>", return "<code>Disabled</code>".
+    1. If |feature| is present in |policy|'s <a for="permissions policy">declared
+       policy</a>:
+        1. If the <a>allowlist</a> for |feature| in |policy|'s <a for="permissions
+           policy">declared policy</a> <a>matches</a> |origin|, then return
+           "<code>Enabled</code>".
+        1. Otherwise return "<code>Disabled</code>".
+    1. Return "<code>Enabled</code>".
 
     </div>
   </section>


### PR DESCRIPTION
This fixes the issue https://github.com/w3c/webappsec-permissions-policy/issues/512 by replacing the algorithm used by `Define an inherited policy for feature in container at origin` for step#2 and step#3 from `Is feature enabled in document for origin?` to a new algorithm, which only checks whether the feature is allowed for origin with the parent frame's inherited policy and declared policy. Chrome is already doing this.

Note that we cannot let `Is feature enabled in document for origin?` to adopt this new algorithm because `Is feature enabled in document for origin?` needs to return `true` early when the feature is allowed by both inherited policy and declared policy, whereas the new algorithm could also `true` for when the feature is absent from the declared policy but allowed by inherited policy.

Fixes https://github.com/w3c/webappsec-permissions-policy/issues/512


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shuranhuang/webappsec-permissions-policy/pull/517.html" title="Last updated on Jun 5, 2023, 5:56 PM UTC (3f55b63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/517/388f33c...shuranhuang:3f55b63.html" title="Last updated on Jun 5, 2023, 5:56 PM UTC (3f55b63)">Diff</a>