### PR TITLE
Clarify self and src origin naming

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -319,9 +319,12 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
     <ul>
       <li><dfn>The special value <code>*</code></dfn>, which represents every
       origin, or</li>
-      <li>An <a>ordered set</a> of <a>permissions-source-expression</a>s and
-      two optional [=origins=], one representing `self` called <dfn>`self` origin</dfn>
-      and one representing `src` called <dfn>`src` origin</dfn>.</li>
+      <li>A struct containing:</li>
+      <ul>
+        <li><dfn>expressions</dfn>, which is an ordered set of <a>permissions-source-expression</a></li>
+        <li><dfn>self-origin</dfn>, which is an [=origin=] or `null`</li>
+        <li><dfn>src-origin</dfn>, which is an [=origin=] or `null`</li>
+      </ul>
     </ul>
     <div class="note">
       The keywords <code>'self'</code>, <code>'src'</code>, and
@@ -340,15 +343,15 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
 
       Note: We are not using the CSP variant of wildcard matching as it requires the HTTPS scheme.
       
-      1. If the <a>allowlist</a> contains a <a>`self` origin</a>,
-         and it is [=same origin-domain=] with <var>origin</var>, then return true.
+      1. If the <a>allowlist</a>'s <a>self-origin</a> is not null and it is
+         [=same origin-domain=] with <var>origin</var>, then return true.
       
-      1. If the <a>allowlist</a> contains a <a>`src` origin</a>,
-         and it is [=same origin-domain=] with <var>origin</var>, then return true.
+      1. If the <a>allowlist</a>'s <a>src-origin</a> is not null and it is
+         [=same origin-domain=] with <var>origin</var>, then return true.
 
       1. If <var>origin</var> is opaque, return false.
 
-      1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
+      1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the  <a>allowlist</a>'s <a>expressions</a>:
 
         1. If the result of running <a>Does url match expression in origin with redirect count?</a>
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
@@ -689,11 +692,11 @@ partial interface HTMLIFrameElement {
     6. If |allowlist| is the special value `*`:
         1. Append "`*`" to |result|
         2. Return |result|.
-    7. If the <a>allowlist</a> contains a <a>`self` origin</a>,
+    7. If the <a>allowlist</a>'s <a>self-origin</a> is not null,
        append the <a lt="serialization of an origin">serialization</a> of it to |result|
-    8. If the <a>allowlist</a> contains a <a>`src` origin</a>,
+    8. If the <a>allowlist</a>'s <a>src-origin</a> is not null,
        append the <a lt="serialization of an origin">serialization</a> of it to |result|
-    9. Otherwise, for each <a>permissions-source-expression</a> |item| in |allowlist|:
+    9. Otherwise, for each <a>permissions-source-expression</a> |item| in |allowlist|'s <a>expressions</a>:
         1. Append |item| to |result|
     10. Return |result|.
 
@@ -830,17 +833,16 @@ partial interface HTMLIFrameElement {
           <a>policy-controlled feature</a>, then [=iteration/continue=].
         1. Let |feature| be the <a>policy-controlled feature</a> identified by
           |feature-name|.
-        1. Let |allowlist| be a new <a>allowlist</a> that is an empty [=ordered
-           set=].
+        1. Let |allowlist| be a new <a>allowlist</a>.
         1. If |value| is the token `*`, or if |value| is a list which contains
           the token `*`, set |allowlist| to <a>the special value
           <code>*</code></a>.
         1. Otherwise:
-            1. If |value| is the token `self`, let the <a>`self` origin</a> in |allowlist| be |origin|.
+            1. If |value| is the token `self`, let |allowlist|'s <a>self-origin</a> be |origin|.
             1. Otherwise if |value| is a [=list=], then [=list/for each=]
                |element| in |value|:
-                1. If |element| is the token `self`, let the <a>`self` origin</a> in |allowlist| be |origin|.
-                1. If |element| is a valid <a>permissions-source-expression</a>, [=list/append=] |element| to |allowlist|.
+                1. If |element| is the token `self`, let |allowlist|'s <a>self-origin</a> be |origin|.
+                1. If |element| is a valid <a>permissions-source-expression</a>, [=list/append=] |element| to |allowlist|'s <a>expressions</a>.
         1. Set |policy|[|feature|] to |allowlist|.
     1. Return |policy|.
 
@@ -867,28 +869,27 @@ partial interface HTMLIFrameElement {
         1. Let |feature| be the <a>policy-controlled feature</a> identified by
           |feature-name|.
         1. Let |targetlist| be the remaining elements, if any, of |tokens|.
-        1. Let |allowlist| be a new <a>allowlist</a> that is an empty [=ordered
-           set=].
+        1. Let |allowlist| be a new <a>allowlist</a>.
         1. If any element of |targetlist| is the string "<code>*</code>", set
           |allowlist| to <a>the special value <code>*</code></a>.
         1. Otherwise:
             1. If |targetlist| is empty and |target origin| is given,
-               let the <a>`src` origin</a> in |allowlist| be |target origin|.
+               let |allowlist|'s <a>src-origin</a> be |target origin|.
             1. For each |element| in |targetlist|:
                 1. If |element| is an <a>ASCII case-insensitive</a> match for
                   "<code>'self'</code>":
-                    1. Let the <a>`self` origin</a> in |allowlist| be |container origin|.
+                    1. Let |allowlist|'s <a>self-origin</a> be |container origin|.
                     1. Continue to the next |element|.
                 1. If |target origin| is given, and |element| is an <a>ASCII
                   case-insensitive</a> match for "<code>'src'</code>":
-                    1. Let the <a>`src` origin</a> in |allowlist| be |target origin|.
+                    1. Let |allowlist|'s <a>src-origin</a> be |target origin|.
                     1. Continue to the next |element|.
                 1. Let |result| be the result of executing the <a>URL parser</a> on |element|.
                 1. If |result| is not failure:
                     1. Let |target| be the [=url/origin=] of |result|.
                     1. If |target| is not an [=opaque origin=], [=list/append=]
                        the <a lt="serialization of an origin">serialization</a>
-                       of |target| to |allowlist|.
+                       of |target| to |allowlist|'s <a>expressions</a>.
         1. Set |directive|[|feature|] to |allowlist|.
     1. Return |directive|
 

--- a/index.bs
+++ b/index.bs
@@ -320,7 +320,8 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
       <li><dfn>The special value <code>*</code></dfn>, which represents every
       origin, or</li>
       <li>An <a>ordered set</a> of <a>permissions-source-expression</a>s and
-      up to two additional [=origins=] (one representing `self` and one representing `src`).</li>
+      two optional [=origins=], one representing `self` called <dfn>`self` origin</dfn>
+      and one representing `src` called <dfn>`src` origin</dfn>.</li>
     </ul>
     <div class="note">
       The keywords <code>'self'</code>, <code>'src'</code>, and
@@ -339,10 +340,10 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
 
       Note: We are not using the CSP variant of wildcard matching as it requires the HTTPS scheme.
       
-      1. If the <a>allowlist</a> contains an [=origin=] representing `self`,
+      1. If the <a>allowlist</a> contains a <a>`self` origin</a>,
          and it is [=same origin-domain=] with <var>origin</var>, then return true.
       
-      1. If the <a>allowlist</a> contains an [=origin=] representing `src`,
+      1. If the <a>allowlist</a> contains a <a>`src` origin</a>,
          and it is [=same origin-domain=] with <var>origin</var>, then return true.
 
       1. If <var>origin</var> is opaque, return false.
@@ -688,9 +689,9 @@ partial interface HTMLIFrameElement {
     6. If |allowlist| is the special value `*`:
         1. Append "`*`" to |result|
         2. Return |result|.
-    7. If the <a>allowlist</a> contains an [=origin=] representing `self`,
+    7. If the <a>allowlist</a> contains a <a>`self` origin</a>,
        append the <a lt="serialization of an origin">serialization</a> of it to |result|
-    8. If the <a>allowlist</a> contains an [=origin=] representing `src`,
+    8. If the <a>allowlist</a> contains a <a>`src` origin</a>,
        append the <a lt="serialization of an origin">serialization</a> of it to |result|
     9. Otherwise, for each <a>permissions-source-expression</a> |item| in |allowlist|:
         1. Append |item| to |result|
@@ -835,10 +836,10 @@ partial interface HTMLIFrameElement {
           the token `*`, set |allowlist| to <a>the special value
           <code>*</code></a>.
         1. Otherwise:
-            1. If |value| is the token `self`, let the [=origin=] representing `self` in |allowlist| be |origin|.
+            1. If |value| is the token `self`, let the <a>`self` origin</a> in |allowlist| be |origin|.
             1. Otherwise if |value| is a [=list=], then [=list/for each=]
                |element| in |value|:
-                1. If |element| is the token `self`, let the [=origin=] representing `self` in |allowlist| be |origin|.
+                1. If |element| is the token `self`, let the <a>`self` origin</a> in |allowlist| be |origin|.
                 1. If |element| is a valid <a>permissions-source-expression</a>, [=list/append=] |element| to |allowlist|.
         1. Set |policy|[|feature|] to |allowlist|.
     1. Return |policy|.
@@ -872,15 +873,15 @@ partial interface HTMLIFrameElement {
           |allowlist| to <a>the special value <code>*</code></a>.
         1. Otherwise:
             1. If |targetlist| is empty and |target origin| is given,
-               let the [=origin=] representing `src` in |allowlist| be |target origin|.
+               let the <a>`src` origin</a> in |allowlist| be |target origin|.
             1. For each |element| in |targetlist|:
                 1. If |element| is an <a>ASCII case-insensitive</a> match for
                   "<code>'self'</code>":
-                    1. Let the [=origin=] representing `self` in |allowlist| be |container origin|.
+                    1. Let the <a>`self` origin</a> in |allowlist| be |container origin|.
                     1. Continue to the next |element|.
                 1. If |target origin| is given, and |element| is an <a>ASCII
                   case-insensitive</a> match for "<code>'src'</code>":
-                    1. Let the [=origin=] representing `src` in |allowlist| be |target origin|.
+                    1. Let the <a>`src` origin</a> in |allowlist| be |target origin|.
                     1. Continue to the next |element|.
                 1. Let |result| be the result of executing the <a>URL parser</a> on |element|.
                 1. If |result| is not failure:

--- a/index.bs
+++ b/index.bs
@@ -351,7 +351,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
 
       1. If <var>origin</var> is opaque, return false.
 
-      1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the  <a>allowlist</a>'s <a>expressions</a>:
+      1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>'s <a>expressions</a>:
 
         1. If the result of running <a>Does url match expression in origin with redirect count?</a>
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.


### PR DESCRIPTION
Since the Allowlist has two optional members we need a clearer way to refer to them.

closes #520


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/pull/522.html" title="Last updated on Jun 28, 2023, 3:02 PM UTC (ee94c6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/522/dbb0ffb...ee94c6e.html" title="Last updated on Jun 28, 2023, 3:02 PM UTC (ee94c6e)">Diff</a>