### PR TITLE
Use exported DFNs from CSP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -342,10 +342,13 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
 
       1. If <var>origin</var> is opaque, return false.
 
+      1. Let <var>url</var> be the result of calling the [=url parser=] on the
+         [=serialization of an origin|serialization=] of <var>origin</var>.
+
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
         1. If the result of running [=Does url match expression in origin with redirect count?=]
-           on a [=url=] of <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
+           on <var>url</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.
     </div>

--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,8 @@ spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
 spec:fetch; type:dfn; text:value
 spec:infra; type:dfn; text:list
+spec:csp3; type:dfn; text:scheme-source
+spec:csp3; type:dfn; text:host-source
 </pre>
 <pre class="anchors">
 spec:payment-request; urlPrefix: https://w3c.github.io/payment-request/

--- a/index.bs
+++ b/index.bs
@@ -349,7 +349,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       1. Let <var>url</var> be the result of calling the [=url parser=] on the
          [=serialization of an origin|serialization=] of <var>origin</var>.
 
-      1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>'s <a>expressions</a>:
+      1. [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>'s <a>expressions</a>:
 
         1. If the result of running [=Does url match expression in origin with redirect count?=]
            on <var>url</var>, |item|, <var>origin</var>, and 0 is true then return true.

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,10 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
 spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
   type: dfn
     text: sh-dictionary; url: dictionary
+spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
+  type: dfn
+    text: scheme-source; url: grammardef-scheme-source
+    text: host-source; url: grammardef-host-source
 </pre>
 <pre class="biblio">
 {

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <l>scheme-source</l> / <l>host-source</l>
+      <dfn>permissions-source-expression</dfn> = <l>{{scheme-source}}</l> / <l>{{host-source}}</l>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = [=scheme-source=] / [=host-source=]
+      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <l>[=scheme-source=]</l> / <l>[=host-source=]</l>
+      <dfn>permissions-source-expression</dfn> = <l>scheme-source</l> / <l>host-source</l>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -344,7 +344,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
 
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
-        1. If the result of running [=Does url match expression in origin with redirect count?=]
+        1. If the result of running [=Does |url| match |expression| in |origin| with |redirect count|?=]
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.

--- a/index.bs
+++ b/index.bs
@@ -349,7 +349,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       1. Let <var>url</var> be the result of calling the [=url parser=] on the
          [=serialization of an origin|serialization=] of <var>origin</var>.
 
-      1. [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>'s <a>expressions</a>:
+      1. [=set/For each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>'s <a>expressions</a>:
 
         1. If the result of running [=Does url match expression in origin with redirect count?=]
            on <var>url</var>, |item|, <var>origin</var>, and 0 is true then return true.
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
+      <dfn>permissions-source-expression</dfn> = {{scheme-source}} / {{host-source}}
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = [=scheme-source=] / [=host-source=]
+      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <l>{{scheme-source}}</l> / <l>{{host-source}}</l>
+      <dfn>permissions-source-expression</dfn> = <l>[$scheme-source$]</l> / <l>[$host-source$]</l>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = {{scheme-source}} / {{host-source}}
+      <dfn>permissions-source-expression</dfn> = [=scheme-source=] / [=host-source=]
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -344,7 +344,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
 
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
-        1. If the result of running [=Does url match expression in origin with redirect count=]
+        1. If the result of running [=Does url match expression in origin with redirect count?=]
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <<scheme-source>> / <<host-source>>
+      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -34,11 +34,6 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
 spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
   type: dfn
     text: sh-dictionary; url: dictionary
-spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
-  type: dfn
-    text: scheme-source; url: grammardef-scheme-source
-    text: host-source; url: grammardef-host-source
-    text: Does url match expression in origin with redirect count?; url: match-url-to-source-expression
 </pre>
 <pre class="biblio">
 {
@@ -349,7 +344,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
 
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
-        1. If the result of running <a>Does url match expression in origin with redirect count?</a>
+        1. If the result of running [=Does url match expression in origin with redirect count?=]
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.
@@ -398,7 +393,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
+      <dfn>permissions-source-expression</dfn> = [=scheme-source=] / [=host-source=]
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -344,7 +344,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
 
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
-        1. If the result of running [=Does |url| match |expression| in |origin| with |redirect count|?=]
+        1. If the result of running [=Does url match expression in origin with redirect count=]
            on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <l><<scheme-source>></l> / <l><<host-source>></l>
+      <dfn>permissions-source-expression</dfn> = <<scheme-source>> / <<host-source>>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -22,8 +22,6 @@ spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
 spec:fetch; type:dfn; text:value
 spec:infra; type:dfn; text:list
-spec:csp3; type:dfn; text:scheme-source
-spec:csp3; type:dfn; text:host-source
 </pre>
 <pre class="anchors">
 spec:payment-request; urlPrefix: https://w3c.github.io/payment-request/

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <l>[$scheme-source$]</l> / <l>[$host-source$]</l>
+      <dfn>permissions-source-expression</dfn> = <l><<scheme-source>></l> / <l><<host-source>></l>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -34,10 +34,6 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
 spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
   type: dfn
     text: sh-dictionary; url: dictionary
-spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
-  type: dfn
-    text: scheme-source; url: grammardef-scheme-source
-    text: host-source; url: grammardef-host-source
 </pre>
 <pre class="biblio">
 {
@@ -404,7 +400,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
+      <dfn>permissions-source-expression</dfn> = <l>[=scheme-source=]</l> / <l>[=host-source=]</l>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>permissions-source-expression</a> / "*" / "'self'" / "'src'" / "'none'"
-      <dfn>permissions-source-expression</dfn> = <a>scheme-source</a> / <a>host-source</a>
+      <dfn>permissions-source-expression</dfn> = <a grammar>scheme-source</a> / <a grammar>host-source</a>
     </pre>
     <div class="note">
       The string "<code>'self'</code>" may be used as an origin in an

--- a/index.bs
+++ b/index.bs
@@ -345,7 +345,7 @@ spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
         1. If the result of running [=Does url match expression in origin with redirect count?=]
-           on <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
+           on a [=url=] of <var>origin</var>, |item|, <var>origin</var>, and 0 is true then return true.
 
       1. Return false.
     </div>


### PR DESCRIPTION
Added in https://github.com/w3c/webappsec-csp/pull/607

closes https://github.com/w3c/webappsec-csp/issues/604
closes https://github.com/w3c/webappsec-permissions-policy/issues/519


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/pull/523.html" title="Last updated on Jul 5, 2023, 2:36 PM UTC (5833bc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/523/6a673ac...5833bc4.html" title="Last updated on Jul 5, 2023, 2:36 PM UTC (5833bc4)">Diff</a>