### PR TITLE
Update [=opaque origin=] refs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -345,7 +345,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
       1. If the <a>allowlist</a> contains an [=origin=] representing `src`,
          and it is [=same origin-domain=] with <var>origin</var>, then return true.
 
-      1. If <var>origin</var> is opaque, return false.
+      1. If <var>origin</var> is an [=opaque origin=], return false.
 
       1. Otherwise, [=set/for each=] <a>permissions-source-expression</a> |item| in the <a>allowlist</a>:
 
@@ -717,10 +717,10 @@ partial interface HTMLIFrameElement {
     <p>To get the <dfn>declared origin</dfn> for an Element |node|, run the
     following steps:
         1. If |node|'s <a>node document</a>'s <a>sandboxed origin browsing
-            context flag</a> is set, then return a unique opaque origin.
+            context flag</a> is set, then return a unique [=opaque origin=].
         2. If |node|'s <{iframe/sandbox}> attribute is set, and does not contain
             the <code>allow-same-origin</code> keyword, then return a unique
-            opaque origin.
+            [=opaque origin=].
         3. If |node|'s <{iframe/srcdoc}> attribute is set, then return |node|'s
             <a>node document</a>'s origin.
         4. If |node|'s <{iframe/src}> attribute is set:

--- a/index.bs
+++ b/index.bs
@@ -717,9 +717,9 @@ partial interface HTMLIFrameElement {
     <p>To get the <dfn>declared origin</dfn> for an Element |node|, run the
     following steps:
         1. If |node|'s <a>node document</a>'s <a>sandboxed origin browsing
-            context flag</a> is set, then return a unique [=opaque origin=].
+            context flag</a> is set, then return a new [=opaque origin=].
         2. If |node|'s <{iframe/sandbox}> attribute is set, and does not contain
-            the <code>allow-same-origin</code> keyword, then return a unique
+            the <code>allow-same-origin</code> keyword, then return a new
             [=opaque origin=].
         3. If |node|'s <{iframe/srcdoc}> attribute is set, then return |node|'s
             <a>node document</a>'s origin.


### PR DESCRIPTION
closes https://github.com/w3c/webappsec-permissions-policy/issues/521


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/pull/524.html" title="Last updated on Jun 30, 2023, 2:53 PM UTC (80087a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/524/dbb0ffb...80087a8.html" title="Last updated on Jun 30, 2023, 2:53 PM UTC (80087a8)">Diff</a>