### PR TITLE
Structured Field Values for HTTP are now RFC8941

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,7 +31,7 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   type: dfn
     text: report type
     text: visible to reportingobservers
-spec: HEADER-STRUCTURE; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#name-dictionaries
+spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   type: dfn
     text: sf-dictionary; url: dictionary
 spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
@@ -42,16 +42,6 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
 </pre>
 <pre class="biblio">
 {
-  "HEADER-STRUCTURE": {
-    "authors": [
-      "Mark Nottingham",
-      "Poul-Henning Kamp"
-    ],
-    "href": "https://datatracker.ietf.org/doc/html/rfc8941",
-    "title": "Structured Field Values for HTTP",
-    "status": "Draft",
-    "publisher": "IETF"
-  }
 }
 </pre>
 <style>
@@ -414,7 +404,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
   <section>
     <h3 id="structured-header-serialization">Structured header serialization</h3>
     <a>Policy Directives</a> in HTTP headers are represented as Structured
-    Fields. [[!HEADER-STRUCTURE]]
+    Fields. [[!RFC8941]]
 
     In this representation, a <a>policy directive</a> is represented by a
     Dictionary.

--- a/index.bs
+++ b/index.bs
@@ -31,9 +31,9 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   type: dfn
     text: report type
     text: visible to reportingobservers
-spec: HEADER-STRUCTURE; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
+spec: HEADER-STRUCTURE; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#name-dictionaries
   type: dfn
-    text: sh-dictionary; url: dictionary
+    text: sf-dictionary; url: dictionary
 spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
   type: dfn
     text: scheme-source; url: grammardef-scheme-source
@@ -47,7 +47,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
       "Mark Nottingham",
       "Poul-Henning Kamp"
     ],
-    "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-18",
+    "href": "https://datatracker.ietf.org/doc/html/rfc8941",
     "title": "Structured Field Values for HTTP",
     "status": "Draft",
     "publisher": "IETF"
@@ -308,7 +308,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
     directive</dfn> is an [=ordered map=], mapping <a>policy-controlled
     features</a> to corresponding <a>allowlists</a> of origins.</p>
     <p>A <a>policy directive</a> is represented in HTTP headers as the
-    serialization of an <a>sh-dictionary</a> structure, and in and HTML
+    serialization of an <a>sf-dictionary</a> structure, and in and HTML
     attributes as its ASCII serialization.</p>
   </section>
   <section>
@@ -448,7 +448,7 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/#
     <p><a http-header>Permissions-Policy</a> is a structured header. Its value
     must be a dictionary. It's ABNF is:
     <pre class="abnf">
-      PermissionsPolicy = <a>sh-dictionary</a>
+      PermissionsPolicy = <a>sf-dictionary</a>
     </pre>
     The semantics of the dictionary are defined in
     [[#structured-header-serialization]].


### PR DESCRIPTION
- Fix links and reference to RFC8941.
- Sh-dictionary is now called sf-dictionary
- Fix https://github.com/w3c/webappsec-permissions-policy/issues/433


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JannisBush/webappsec-permissions-policy/pull/526.html" title="Last updated on Aug 24, 2023, 1:25 PM UTC (23db2d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/526/eb5199e...JannisBush:23db2d8.html" title="Last updated on Aug 24, 2023, 1:25 PM UTC (23db2d8)">Diff</a>