### PR TITLE
In features.md: Rename FLEDGE to Protected Audience

### DIFF
--- a/features.md
+++ b/features.md
@@ -78,11 +78,11 @@ experimentation by web developers.
 | Feature name | Link(s) | Browser Support |
 | ------------ | ------- | --------------- |
 | `browsing-topics` | [Explainer](https://github.com/jkarlin/topics/) | Status "[Started](https://bugs.chromium.org/p/chromium/issues/detail?id=1294456)" in Chrome |
-| `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[3](#fn4)</sup> |
+| `conversion-measurement ` | [Explainer](https://github.com/WICG/conversion-measurement-api#publisher-controls-for-impression-declaration) | Experimental in Chrome<sup>[3](#fn3)</sup> |
 | `focus-without-user-activation` | [focus-without-user-activation.md](policies/focus-without-user-activation.md) | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=965495)" in Chrome |
-| `join-ad-interest-group` | [FLEDGE][fledge] | Behind a flag in Chrome<sup>[6](#fn6)</sup> |
+| `join-ad-interest-group` | [Protected Audience (formerly FLEDGE)][protected-audience] | Behind a flag in Chrome<sup>[4](#fn4)</sup> |
 | `local-fonts` | [Local Font Access API][local-fonts] and [Explainer](https://github.com/WICG/local-font-access/blob/main/README.md) | [Experimental in Chrome](https://chromestatus.com/feature/6234451761692672) |
-| `run-ad-auction` | [FLEDGE][fledge] | Behind a flag in Chrome<sup>[6](#fn6)</sup> |
+| `run-ad-auction` | [Protected Audience (formerly FLEDGE)][protected-audience] | Behind a flag in Chrome<sup>[4](#fn4)</sup> |
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Explainer](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/2479231594867458049) in Chrome 84-87 |
 | `unload` | [Explainer](https://github.com/fergald/docs/blob/master/explainers/permissions-policy-unload.md) | Status "[Started](https://crbug.com/1324111) in Chrome |
@@ -109,14 +109,14 @@ and/or implementations have been removed.
 <a name="fn3">[3]</a>: To enable this, use the Chrome command line flag
 `--enable-blink-features=ConversionMeasurement`.
 
-<a name="fn6">[6]</a>: To enable this, use the Chrome command line flag
+<a name="fn4">[4]</a>: To enable this, use the Chrome command line flag
 `--enable-features=AdInterestGroupAPI,InterestGroupStorage,Fledge`.
 
 [battery-status]: https://w3c.github.io/battery/#permissions-policy-integration
 [bluetooth]: https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy
 [client-hints]: https://wicg.github.io/ua-client-hints/
 [encrypted-media]: https://w3c.github.io/encrypted-media/#permissions-policy-integration
-[fledge]: https://wicg.github.io/turtledove/#permissions-policy-integration
+[protected-audience]: https://wicg.github.io/turtledove/#permissions-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#permissions-policy-integration
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [geolocation]: https://w3c.github.io/geolocation-api/#permissions-policy


### PR DESCRIPTION
1. Update name "FLEDGE" to its new name "Protected Audience". See this [renaming announcement ](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge).
2. Change "fn6" to "fn4" for Protected Audience flags note, as 4 and 5 have been removed.
3. Fixed a bug where conversion messurement was using fn4 but should be fn3. (See this [PR](https://github.com/w3c/webappsec-permissions-policy/commit/10b33d2b991b503d6c81ee1f9c6cb0638189a2f5#diff-445e6d0dc97b93a0f04d914ad7816114ddc175dc462c7eec7961921af17ff0d0R81) that changed the text but not the link)