### PR TITLE
Add `documentUrl` to Permissions Policy report

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -776,6 +776,7 @@ partial interface HTMLIFrameElement {
     [Exposed=Window]
     interface PermissionsPolicyViolationReportBody : ReportBody {
       readonly attribute DOMString featureId;
+      readonly attribute DOMString documentUrl;
       readonly attribute DOMString? sourceFile;
       readonly attribute long? lineNumber;
       readonly attribute long? columnNumber;
@@ -791,6 +792,10 @@ partial interface HTMLIFrameElement {
       string identifying the <a>policy-controlled feature</a> whose policy has
       been <a>violated</a>. This string can be used for grouping and counting
       related reports.
+
+    - <dfn for="PermissionsPolicyViolationReportBody">documentUrl</dfn>: The
+      string identifying the document's URL where <a>violated</a> has been
+      occured.
 
     - <dfn for="PermissionsPolicyViolationReportBody">sourceFile</dfn>: If
       known, the file where the <a>violation</a> occured, or null otherwise.
@@ -1105,20 +1110,19 @@ partial interface HTMLIFrameElement {
        permissions policy</a>, given |report-only policy|, |feature|, |origin|,
        and |document|'s [=Document/origin=].
     1. If |report| is True:
-        1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":
             1. Let |endpoint| be the result of calling <a abstract-op>Get the
                 reporting endpoint for a feature</a> given |feature| and
                 |policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |settings|,
+                policy on settings</a> given |feature|, |document|,
                 "<code>Enforce</code>", and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
                 abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |settings|,
+                policy on settings</a> given |feature|, |document|,
                 "<code>Report</code>", and |report-only endpoint|.
     1. Return result
 
@@ -1142,8 +1146,8 @@ partial interface HTMLIFrameElement {
     ## <dfn export abstract-op id="report-permissions-policy-violation">Generate report for violation of permissions policy on settings</dfn> ## {#algo-report-permissions-policy-violation}
 
     <div class="algorithm" data-algorithm="report-permissions-policy-violation">
-    Given a [=feature=] (|feature|), an <a>environment settings object</a>
-    (|settings|), a string (|disposition|), and a string-or-null (|endpoint|),
+    Given a [=feature=] (|feature|), a {{Document}} object
+    (|document|), a string (|disposition|), and a string-or-null (|endpoint|),
     this algorithm generates a <a>report</a> about the <a>violation</a> of the
     policy for |feature|.
 
@@ -1152,6 +1156,8 @@ partial interface HTMLIFrameElement {
 
         :   [=PermissionsPolicyViolationReportBody/featureId=]
         ::  |feature|'s string representation.
+        :   [=PermissionsPolicyViolationReportBody/documentUrl=]
+        ::  |document|'s URL.
         :   [=PermissionsPolicyViolationReportBody/sourceFile=]
         ::  null
         :   [=PermissionsPolicyViolationReportBody/lineNumber=]
@@ -1161,6 +1167,7 @@ partial interface HTMLIFrameElement {
         :   [=PermissionsPolicyViolationReportBody/disposition=]
         ::  |disposition|
 
+    1. Let |settings| be |document|'s <a>environment settings object</a>.
     1. If the user agent is currently executing script, and can extract the
       source file's URL, line number, and column number from |settings|, then
       set |body|'s [=PermissionsPolicyViolationReportBody/sourceFile=],

--- a/index.bs
+++ b/index.bs
@@ -776,7 +776,7 @@ partial interface HTMLIFrameElement {
     [Exposed=Window]
     interface PermissionsPolicyViolationReportBody : ReportBody {
       readonly attribute DOMString featureId;
-      readonly attribute DOMString documentUrl;
+      readonly attribute DOMString documentURL;
       readonly attribute DOMString? sourceFile;
       readonly attribute long? lineNumber;
       readonly attribute long? columnNumber;
@@ -793,7 +793,7 @@ partial interface HTMLIFrameElement {
       been <a>violated</a>. This string can be used for grouping and counting
       related reports.
 
-    - <dfn for="PermissionsPolicyViolationReportBody">documentUrl</dfn>: The
+    - <dfn for="PermissionsPolicyViolationReportBody">documentURL</dfn>: The
       string identifying the document's URL where <a>violation</a> has occured.
 
     - <dfn for="PermissionsPolicyViolationReportBody">sourceFile</dfn>: If
@@ -1155,7 +1155,7 @@ partial interface HTMLIFrameElement {
 
         :   [=PermissionsPolicyViolationReportBody/featureId=]
         ::  |feature|'s string representation.
-        :   [=PermissionsPolicyViolationReportBody/documentUrl=]
+        :   [=PermissionsPolicyViolationReportBody/documentURL=]
         ::  |document|'s URL.
         :   [=PermissionsPolicyViolationReportBody/sourceFile=]
         ::  null

--- a/index.bs
+++ b/index.bs
@@ -1114,15 +1114,15 @@ partial interface HTMLIFrameElement {
                 reporting endpoint for a feature</a> given |feature| and
                 |policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |document|,
-                "<code>Enforce</code>", and |endpoint|.
+                policy</a> given |feature|, |document|, "<code>Enforce</code>",
+                and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
                 abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |document|,
-                "<code>Report</code>", and |report-only endpoint|.
+                policy</a> given |feature|, |document|, "<code>Report</code>",
+                and |report-only endpoint|.
     1. Return result
 
     </div>
@@ -1142,7 +1142,7 @@ partial interface HTMLIFrameElement {
     </div>
   </section>
   <section>
-    ## <dfn export abstract-op id="report-permissions-policy-violation">Generate report for violation of permissions policy on settings</dfn> ## {#algo-report-permissions-policy-violation}
+    ## <dfn export abstract-op id="report-permissions-policy-violation">Generate report for violation of permissions policy</dfn> ## {#algo-report-permissions-policy-violation}
 
     <div class="algorithm" data-algorithm="report-permissions-policy-violation">
     Given a [=feature=] (|feature|), a {{Document}} object

--- a/index.bs
+++ b/index.bs
@@ -794,8 +794,7 @@ partial interface HTMLIFrameElement {
       related reports.
 
     - <dfn for="PermissionsPolicyViolationReportBody">documentUrl</dfn>: The
-      string identifying the document's URL where <a>violated</a> has been
-      occured.
+      string identifying the document's URL where <a>violation</a> has occured.
 
     - <dfn for="PermissionsPolicyViolationReportBody">sourceFile</dfn>: If
       known, the file where the <a>violation</a> occured, or null otherwise.


### PR DESCRIPTION
The [current report structure](https://w3c.github.io/webappsec-permissions-policy/#algo-report-permissions-policy-violation) has  a [sourceFile](https://w3c.github.io/webappsec-permissions-policy/#permissionspolicyviolationreportbody-sourcefile). However, the script might be a third-party library, where the site owner does not know where this script is being executed.

This change adds `documentUrl` to Permissions Policy report for this reason.

Fixes: https://github.com/w3c/webappsec-permissions-policy/issues/536


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shhnjk/webappsec-permissions-policy/pull/541.html" title="Last updated on Feb 7, 2024, 1:16 AM UTC (5eb031b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/541/7a2bc78...shhnjk:5eb031b.html" title="Last updated on Feb 7, 2024, 1:16 AM UTC (5eb031b)">Diff</a>