### PR TITLE
Send reports for Permissions Policy violations in iframe to parent frame's endpoint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1002,7 +1002,8 @@ partial interface HTMLIFrameElement {
         1. Call <a abstract-op>Is feature enabled in document for origin?</a>
            on |feature|, |element|'s [=node document=], |origin|, True, True, and
            |allowAttribute|.
-          Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
+
+        Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
     1. Return |container policy|.
 
     </div>

--- a/index.bs
+++ b/index.bs
@@ -852,12 +852,9 @@ partial interface HTMLIFrameElement {
       string indicating whether the <a>violated</a> permissions policy was
       enforced in this case.
       [=PermissionsPolicyViolationReportBody/disposition=] will be set to
-      "enforce" if the policy was enforced, "report" if the <a>violation</a>
+      "enforce" if the policy was enforced, or "report" if the <a>violation</a>
       resulted only in this report being generated (with no further action taken
-      by the user agent in response to the violation), "potential-enforce" if the
-      policy was potentially enforced on iframes, or "potential-report" if the
-      potential <a>violation</a> on iframes resulted only in this report being
-      generated.
+      by the user agent in response to the violation).
 
     - <dfn for="PermissionsPolicyViolationReportBody">allowAttribute</dfn>: If
       known, the value of <{iframe}> element's <{iframe/allow}> attribute, or 
@@ -1166,22 +1163,30 @@ partial interface HTMLIFrameElement {
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":
             1. Let |endpoint| be the result of calling <a abstract-op>Get the
-                reporting endpoint for a feature</a> given |feature| and
-                |policy|.
-            1. Let |disposition| be "<code>potential-enforce</code>" if
-               |potential| is True, or "<code>enforce</code>" otherwise.
-            1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |settings|,
-                |disposition|, |endpoint|, and |allowAttribute|.
+               reporting endpoint for a feature</a> given |feature| and
+               |policy|.
+            1. If |potential| is True:
+                1. Call <a abstract-op>Generate report for potential violation
+                   of permissions policy on settings</a> given |feature|,
+                   |settings|, "<code>enforce</code>", |endpoint|, and
+                   |allowAttribute|.
+            1. Else:
+                1. Call <a abstract-op>Generate report for violation of
+                   permissions policy on settings</a> given |feature|, |settings|,
+                   "<code>enforce</code>", and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
-                abstract-op>Get the reporting endpoint for a feature</a> given
+               abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
-            1. Let |disposition| be "<code>potential-report</code>" if
-               |potential| is True, or "<code>report</code>" otherwise.
-            1. Call <a abstract-op>Generate report for violation of permissions
-                policy on settings</a> given |feature|, |settings|,
-                |potential|, |report-only endpoint|, and |allowAttribute|.
+            1. If |potential| is True:
+                1. Call <a abstract-op>Generate report for potential violation of
+                   permissions policy on settings</a> given |feature|, |settings|,
+                   "<code>report</code>", |report-only endpoint|, and
+                   |allowAttribute|.
+            1. Else:
+                1. Call <a abstract-op>Generate report for violation of permissions
+                   policy on settings</a> given |feature|, |settings|,
+                   "<code>report</code>", and |report-only endpoint|.
     1. Return result
 
     </div>
@@ -1222,6 +1227,40 @@ partial interface HTMLIFrameElement {
         ::  null
         :   [=PermissionsPolicyViolationReportBody/disposition=]
         ::  |disposition|
+
+    1. If the user agent is currently executing script, and can extract the
+      source file's URL, line number, and column number from |settings|, then
+      set |body|'s [=PermissionsPolicyViolationReportBody/sourceFile=],
+      [=PermissionsPolicyViolationReportBody/lineNumber=], and
+      [=PermissionsPolicyViolationReportBody/columnNumber=] accordingly.
+
+    1. Execute [=generate and queue a report=] with |body|,
+      "permissions-policy-violation", |endpoint|, and |settings|.
+
+    </div>
+  </section>
+  <section>
+    ## <dfn export abstract-op id="report-potential-permissions-policy-violation">Generate report for potential violation of permissions policy on settings</dfn> ## {#algo-report-potential-permissions-policy-violation}
+
+    <div class="algorithm" data-algorithm="report-potential-permissions-policy-violation">
+    Given a [=policy-controlled feature|feature=] (|feature|), an <a>environment settings object</a>
+    (|settings|), a string (|disposition|), a string-or-null (|endpoint|), and a string-or-null
+    (|allowAttribute|), this algorithm generates a <a>report</a> about the <a>violation</a> of the
+    policy for |feature|.
+
+    1. Let |body| be a new {{PermissionsPolicyViolationReportBody}}, initialized
+      as follows:
+
+        :   [=PermissionsPolicyViolationReportBody/featureId=]
+        ::  |feature|'s string representation.
+        :   [=PermissionsPolicyViolationReportBody/sourceFile=]
+        ::  null
+        :   [=PermissionsPolicyViolationReportBody/lineNumber=]
+        ::  null
+        :   [=PermissionsPolicyViolationReportBody/columnNumber=]
+        ::  null
+        :   [=PermissionsPolicyViolationReportBody/disposition=]
+        ::  |disposition|
         :   [=PermissionsPolicyViolationReportBody/allowAttribute=]
         ::  |allowAttribute|
 
@@ -1236,7 +1275,7 @@ partial interface HTMLIFrameElement {
        |allowAttribute|.
 
     1. Execute [=generate and queue a report=] with |body|,
-      "permissions-policy-violation", |endpoint|, and |settings|.
+      "potential-permissions-policy-violation", |endpoint|, and |settings|.
 
     </div>
   </section>

--- a/index.bs
+++ b/index.bs
@@ -1209,7 +1209,7 @@ partial interface HTMLIFrameElement {
           2. Call <a abstract-op>Generate report for potential violation
              of permissions policy on settings</a> given |feature|,
              |settings|, "<code>Enforce</code>", and |endpoint|.
-        2. If the result of running <a abstract-op>Define an inherited
+        2. Else, if the result of running <a abstract-op>Define an inherited
            policy for feature in container at origin</a> on |feature|,
            |container|, |container|'s <a>declared origin</a> and True is
            "<code>Disabled</code>":

--- a/index.bs
+++ b/index.bs
@@ -764,12 +764,35 @@ partial interface HTMLIFrameElement {
     <p>To get the <a>observable policy</a> for an Element |node|, run the
     following steps:</p>
         1. Let |inherited policy| be an empty [=ordered map=].
-        3. [=set/For each=] <a>supported feature</a> |feature|:
+        2. [=set/For each=] <a>supported feature</a> |feature|:
             1. Let |isInherited| be the result of running <a abstract-op>Define
                 an inherited policy for feature in container at origin</a> on
                 |feature|, |node| and |node|'s <a>declared origin</a>.
             2. Set |inherited policy|[|feature|] to |isInherited|.
-        4. Return a new <a>permissions policy</a> with <a for="permissions
+            3. If |node| is a <a>navigable container</a>:
+              1. Let |document| be |node|'s <a>node document</a>.
+              2. Let |settings| be |document|'s <a>environment settings
+                 object</a>.
+              3. If |isInherited| is "<code>Disabled</code>":
+                1. Let |endpoint| be the result of calling <a abstract-op>Get
+                   the reporting endpoint for a feature</a> given |feature| and
+                   |document|'s [=Document/permissions policy=].
+                2. Call <a abstract-op>Generate report for potential violation
+                   of permissions policy on settings</a> given |feature|,
+                   |settings|, "<code>Enforce</code>", and |endpoint|.
+              4. If the result of running <a abstract-op>Define an inherited
+                 policy for feature in container at origin</a> on |feature|,
+                 |node|, |node|'s <a>declared origin</a> and True is
+                 "<code>Disabled</code>":
+                1. Let |report-only endpoint| be the result of calling <a
+                   abstract-op>Get the reporting endpoint for a feature</a>
+                   given |feature| and |document|'s [=Document/report-only
+                   permissions policy=].
+                2. Call <a abstract-op>Generate report for potential violation
+                   of permissions policy on settings</a> given |feature|,
+                   |settings|, "<code>Report</code>", and |report-only
+                   endpoint|.
+        3. Return a new <a>permissions policy</a> with <a for="permissions
            policy">inherited policy</a> |inherited policy|, <a
            for="permissions policy">declared policy</a> a [=struct=] with both
            [=declared policy/declarations=] and [=declared policy/reporting

--- a/index.bs
+++ b/index.bs
@@ -856,9 +856,10 @@ partial interface HTMLIFrameElement {
       resulted only in this report being generated (with no further action taken
       by the user agent in response to the violation).
 
-    - <dfn for="PermissionsPolicyViolationReportBody">allowAttribute</dfn>: If
-      known, the value of <{iframe}> element's <{iframe/allow}> attribute, or 
-      null otherwise.
+    - <dfn for="PermissionsPolicyViolationReportBody">allowAttribute</dfn>: For
+      reports of potential violations, which can be attributed to a specific
+      <{iframe}> element, the value of the <{iframe/allow}> attribute of that
+      element, or omitted otherwise.
 
   <section>
     <h3 id="permissions-policy-report-only-http-header-field">\``Permissions-Policy-Report-Only`\` HTTP Header Field</h3>

--- a/index.bs
+++ b/index.bs
@@ -995,13 +995,14 @@ partial interface HTMLIFrameElement {
        <code>fullscreen</code> [=policy-controlled feature|feature=].
       1. [=map/Set=] |container policy|[<code>fullscreen</code>] = <a>the
          special value <code>*</code></a>.
-    1. [=map/For each=] [=feature=] in |container policy|:
+    1. [=map/For each=] |feature| in |container policy|:
       1. If [=feature=]'s <a>allowlist</a> does not [=list/contain=] <a>the special
-         value <code>*</code></a>, then [=list/for each=] [=origins=] in
+         value <code>*</code></a>, then [=list/for each=] |origin| in
          <a>allowlist</a>:
-        1. Executing <a abstract-op>Is feature enabled in document for origin?</a>
+        1. Call <a abstract-op>Is feature enabled in document for origin?</a>
            on |feature|, |element|'s [=node document=], |origin|, True, True, and
            |allowAttribute|.
+        Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
     1. Return |container policy|.
 
     </div>
@@ -1269,10 +1270,6 @@ partial interface HTMLIFrameElement {
       set |body|'s [=PermissionsPolicyViolationReportBody/sourceFile=],
       [=PermissionsPolicyViolationReportBody/lineNumber=], and
       [=PermissionsPolicyViolationReportBody/columnNumber=] accordingly.
-
-    1. If |allowAttribute| is not null, then set |body|'s
-       [=PermissionsPolicyViolationReportBody/allowAttribute=] to
-       |allowAttribute|.
 
     1. Execute [=generate and queue a report=] with |body|,
       "potential-permissions-policy-violation", |endpoint|, and |settings|.

--- a/index.bs
+++ b/index.bs
@@ -764,35 +764,12 @@ partial interface HTMLIFrameElement {
     <p>To get the <a>observable policy</a> for an Element |node|, run the
     following steps:</p>
         1. Let |inherited policy| be an empty [=ordered map=].
-        2. [=set/For each=] <a>supported feature</a> |feature|:
+        3. [=set/For each=] <a>supported feature</a> |feature|:
             1. Let |isInherited| be the result of running <a abstract-op>Define
                 an inherited policy for feature in container at origin</a> on
                 |feature|, |node| and |node|'s <a>declared origin</a>.
             2. Set |inherited policy|[|feature|] to |isInherited|.
-            3. If |node| is a <a>navigable container</a>:
-              1. Let |document| be |node|'s <a>node document</a>.
-              2. Let |settings| be |document|'s <a>environment settings
-                 object</a>.
-              3. If |isInherited| is "<code>Disabled</code>":
-                1. Let |endpoint| be the result of calling <a abstract-op>Get
-                   the reporting endpoint for a feature</a> given |feature| and
-                   |document|'s [=Document/permissions policy=].
-                2. Call <a abstract-op>Generate report for potential violation
-                   of permissions policy on settings</a> given |feature|,
-                   |settings|, "<code>Enforce</code>", and |endpoint|.
-              4. If the result of running <a abstract-op>Define an inherited
-                 policy for feature in container at origin</a> on |feature|,
-                 |node|, |node|'s <a>declared origin</a> and True is
-                 "<code>Disabled</code>":
-                1. Let |report-only endpoint| be the result of calling <a
-                   abstract-op>Get the reporting endpoint for a feature</a>
-                   given |feature| and |document|'s [=Document/report-only
-                   permissions policy=].
-                2. Call <a abstract-op>Generate report for potential violation
-                   of permissions policy on settings</a> given |feature|,
-                   |settings|, "<code>Report</code>", and |report-only
-                   endpoint|.
-        3. Return a new <a>permissions policy</a> with <a for="permissions
+        4. Return a new <a>permissions policy</a> with <a for="permissions
            policy">inherited policy</a> |inherited policy|, <a
            for="permissions policy">declared policy</a> a [=struct=] with both
            [=declared policy/declarations=] and [=declared policy/reporting
@@ -1213,6 +1190,41 @@ partial interface HTMLIFrameElement {
     </div>
   </section>
   <section>
+    ## <dfn abstract-op id="check-potential-violation-in-container">Check potential violation of permissions policy in container</dfn> ## {#algo-check-potential-violation-in-container}
+
+    <div class="algorithm" data-algorithm="check-potential-violation-in-container">
+    Given a <a>navigable container</a> (|container|), this algorithm sends potential
+    violation reports.
+    1. Let |document| be |container|'s <a>node document</a>.
+    2. Let |settings| be |document|'s <a>environment settings
+       object</a>.
+    3. [=set/For each=] <a>supported feature</a> |feature|:
+        1. If the result of running <a abstract-op>Define an inherited
+           policy for feature in container at origin</a> on |feature|,
+           |container| and |container|'s <a>declared origin</a> is
+           "<code>Disabled</code>":
+          1. Let |endpoint| be the result of calling <a abstract-op>Get
+             the reporting endpoint for a feature</a> given |feature| and
+             |document|'s [=Document/permissions policy=].
+          2. Call <a abstract-op>Generate report for potential violation
+             of permissions policy on settings</a> given |feature|,
+             |settings|, "<code>Enforce</code>", and |endpoint|.
+        2. If the result of running <a abstract-op>Define an inherited
+           policy for feature in container at origin</a> on |feature|,
+           |container|, |container|'s <a>declared origin</a> and True is
+           "<code>Disabled</code>":
+          1. Let |report-only endpoint| be the result of calling <a
+             abstract-op>Get the reporting endpoint for a feature</a>
+             given |feature| and |document|'s [=Document/report-only
+             permissions policy=].
+          2. Call <a abstract-op>Generate report for potential violation
+             of permissions policy on settings</a> given |feature|,
+             |settings|, "<code>Report</code>", and |report-only
+             endpoint|.
+
+    </div>
+  </section>
+  <section>
     ## <dfn export abstract-op id="report-permissions-policy-violation">Generate report for violation of permissions policy on settings</dfn> ## {#algo-report-permissions-policy-violation}
 
     <div class="algorithm" data-algorithm="report-permissions-policy-violation">
@@ -1329,7 +1341,13 @@ partial interface HTMLIFrameElement {
        navigationParams's origin, navigationParams's response, and True.
 
     And in the same section, in step 10, set the new {{Document}}'s
-   [=Document/report-only permissions policy=] to |reportOnlyPermissionsPolicy|.
+    [=Document/report-only permissions policy=] to |reportOnlyPermissionsPolicy|.
+
+    And in the same section, in step 19 before the return, insert the following step:
+
+    19. If navigationParams's navigable's container is not null, call <a
+        abstract-op>Check potential violation of permissions policy in
+        container</a> given navigationParams's navigable's container.
   </section>
 </section>
 

--- a/index.bs
+++ b/index.bs
@@ -809,9 +809,12 @@ partial interface HTMLIFrameElement {
       string indicating whether the <a>violated</a> permissions policy was
       enforced in this case.
       [=PermissionsPolicyViolationReportBody/disposition=] will be set to
-      "enforce" if the policy was enforced, or "report" if the <a>violation</a>
+      "enforce" if the policy was enforced, "report" if the <a>violation</a>
       resulted only in this report being generated (with no further action taken
-      by the user agent in response to the violation).
+      by the user agent in response to the violation), "potential-enforce" if the
+      policy was potentially enforced on iframes, or "potential-report" if the
+      potential <a>violation</a> on iframes resulted only in this report being
+      generated.
 
   <section>
     <h3 id="permissions-policy-report-only-http-header-field">\``Permissions-Policy-Report-Only`\`

--- a/index.bs
+++ b/index.bs
@@ -1002,7 +1002,7 @@ partial interface HTMLIFrameElement {
         1. Call <a abstract-op>Is feature enabled in document for origin?</a>
            on |feature|, |element|'s [=node document=], |origin|, True, True, and
            |allowAttribute|.
-        Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
+          Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
     1. Return |container policy|.
 
     </div>

--- a/index.bs
+++ b/index.bs
@@ -986,25 +986,15 @@ partial interface HTMLIFrameElement {
     policy</a>, which may be empty.
     1. If |element| is not an <{iframe}> element, then return an empty [=policy
        directive=].
-    1. Let |allowAttribute| be the value of |element|'s <{iframe/allow}>
-       attribute.
     1. Let |container policy| be the result of running <a abstract-op>Parse policy
-      directive</a> given |allowAttribute|, the [=Document/origin=] of |element|'s
-      [=node document=], and |element|'s <a>declared origin</a>.
+      directive</a> given the value of |element|'s <{iframe/allow}> attribute,
+      the [=Document/origin=] of |element|'s [=node document=], and |element|'s
+      <a>declared origin</a>.
     1. If |element|'s <{iframe/allowfullscreen}> attribute is specified, and
        |container policy| does not [=map/contain=] an entry for the
        <code>fullscreen</code> [=policy-controlled feature|feature=].
       1. [=map/Set=] |container policy|[<code>fullscreen</code>] = <a>the
          special value <code>*</code></a>.
-    1. [=map/For each=] |feature| in |container policy|:
-      1. If [=feature=]'s <a>allowlist</a> does not [=list/contain=] <a>the special
-         value <code>*</code></a>, then [=list/for each=] |origin| in
-         <a>allowlist</a>:
-        1. Call <a abstract-op>Is feature enabled in document for origin?</a>
-           on |feature|, |element|'s [=node document=], |origin|, True, True, and
-           |allowAttribute|.
-
-        Note: The purpose of the call is to generate a report, and not to allow or deny a feature usage.
     1. Return |container policy|.
 
     </div>
@@ -1137,14 +1127,13 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="is-feature-enabled">
     Given a [=policy-controlled feature|feature=] (|feature|), a {{Document}} object
-    (|document|), an [=origin=] (|origin|), an optional boolean (|report|), with a
-    default value of True, an optional boolean (|potential|) with a default value of
-    False, and an optional string (|allowAttribute|), this algorithm returns
-    "<code>Disabled</code>" if |feature| should be considered disabled, and
-    "<code>Enabled</code>" otherwise. If |report| is True, then it will also
-    [=generate and queue a report=] if the feature is not enabled in either
-    |document|'s [=Document/permissions policy=] or |document|'s
-    [=Document/report-only permissions policy=].
+    (|document|), an [=origin=] (|origin|), and an optional boolean (|report|),
+    with a default value of True, this algorithm returns "<code>Disabled</code>"
+    if |feature| should be considered disabled, and "<code>Enabled</code>"
+    otherwise. If |report| is True, then it will also [=generate and queue a
+    report=] if the feature is not enabled in either |document|'s
+    [=Document/permissions policy=] or |document|'s [=Document/report-only
+    permissions policy=].
 
     Note: The default value of True for |report| means that most permissions
     policy checks will generate a violation report if the feature is not
@@ -1167,29 +1156,17 @@ partial interface HTMLIFrameElement {
         1. If |result| is "<code>Disabled</code>":
             1. Let |endpoint| be the result of calling <a abstract-op>Get the
                reporting endpoint for a feature</a> given |feature| and
-               |policy|.
-            1. If |potential| is True:
-                1. Call <a abstract-op>Generate report for potential violation
-                   of permissions policy on settings</a> given |feature|,
-                   |settings|, "<code>enforce</code>", |endpoint|, and
-                   |allowAttribute|.
-            1. Else:
-                1. Call <a abstract-op>Generate report for violation of
-                   permissions policy on settings</a> given |feature|, |settings|,
-                   "<code>enforce</code>", and |endpoint|.
+                |policy|.
+            1. Call <a abstract-op>Generate report for violation of permissions
+                policy on settings</a> given |feature|, |settings|,
+                "<code>Enforce</code>", and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
                abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
-            1. If |potential| is True:
-                1. Call <a abstract-op>Generate report for potential violation of
-                   permissions policy on settings</a> given |feature|, |settings|,
-                   "<code>report</code>", |report-only endpoint|, and
-                   |allowAttribute|.
-            1. Else:
-                1. Call <a abstract-op>Generate report for violation of permissions
-                   policy on settings</a> given |feature|, |settings|,
-                   "<code>report</code>", and |report-only endpoint|.
+            1. Call <a abstract-op>Generate report for violation of permissions
+                policy on settings</a> given |feature|, |settings|,
+                "<code>Report</code>", and |report-only endpoint|.
     1. Return result
 
     </div>

--- a/index.bs
+++ b/index.bs
@@ -1072,17 +1072,19 @@ partial interface HTMLIFrameElement {
     <div class="algorithm"
     data-algorithm="define-inherited-policy-in-container">
     Given a [=policy-controlled feature|feature=] (|feature|), null or a <a>navigable container</a>
-    (|container|), and an <a for="Document">origin</a> for a {{Document}} in
-    that container (|origin|), this algorithm returns the [=inherited policy for
-    a feature|inherited policy value=] for |feature|.
+    (|container|), an <a for="Document">origin</a> for a {{Document}} in
+    that container (|origin|), and an optional boolean (|report-only|), with
+    a default value of False, this algorithm returns the [=inherited policy
+    for a feature|inherited policy value=] for |feature|.
     1. If |container| is null, return "<code>Enabled</code>".
     1. If the result of executing <a abstract-op>Get feature value for
-      origin</a> on |feature|, |container|'s <a>node document</a>, and
-      |container|'s <a>node document</a>'s origin is
+      origin</a> on |feature|, |container|'s <a>node document</a>,
+      |container|'s <a>node document</a>'s origin, and |report-only| is
       "<code>Disabled</code>", return "<code>Disabled</code>".
     1. If the result of executing <a abstract-op>Get feature value for
-      origin</a> on |feature|, |container|'s <a>node document</a>, and
-      |origin| is "<code>Disabled</code>", return "<code>Disabled</code>".
+      origin</a> on |feature|, |container|'s <a>node document</a>, |origin|,
+      and |report-only| is "<code>Disabled</code>", return
+      "<code>Disabled</code>".
     1. Let |container policy| be the result of running <a abstract-op>Process
       permissions policy attributes</a> on |container|.
     1. If |feature| [=map/exists=] in |container policy|:
@@ -1103,10 +1105,12 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="get-feature-value-for-origin">
     Given a [=policy-controlled feature|feature=] (|feature|), a {{Document}} object
-    (|document|), and an [=origin=] (|origin|), this algorithm
-    returns "<code>Disabled</code>" if |feature| should be considered
-    disabled, and "<code>Enabled</code>" otherwise.
-    1. Let |policy| be |document|'s [=Document/permissions policy=].
+    (|document|), an [=origin=] (|origin|), and a boolean (|report-only|),
+    this algorithm returns "<code>Disabled</code>" if |feature| should be
+    considered disabled, and "<code>Enabled</code>" otherwise.
+    1. Let |policy| be |document|'s [=Document/report-only permissions
+       policy=] if |report-only| is True, or |document|'s
+       [=Document/permissions policy=] otherwise.
     1. If |policy|'s <a for="permissions policy">inherited policy</a> for
        |feature| is "<code>Disabled</code>", return "<code>Disabled</code>".
     1. If |feature| is present in |policy|'s <a for="permissions policy">declared

--- a/index.bs
+++ b/index.bs
@@ -1155,14 +1155,14 @@ partial interface HTMLIFrameElement {
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":
             1. Let |endpoint| be the result of calling <a abstract-op>Get the
-               reporting endpoint for a feature</a> given |feature| and
+                reporting endpoint for a feature</a> given |feature| and
                 |policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,
                 "<code>Enforce</code>", and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
-               abstract-op>Get the reporting endpoint for a feature</a> given
+                abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,

--- a/index.bs
+++ b/index.bs
@@ -780,6 +780,7 @@ partial interface HTMLIFrameElement {
       readonly attribute long? lineNumber;
       readonly attribute long? columnNumber;
       readonly attribute DOMString disposition;
+      readonly attribute DOMString? allowAttribute;
     };
   </pre>
 
@@ -815,6 +816,10 @@ partial interface HTMLIFrameElement {
       policy was potentially enforced on iframes, or "potential-report" if the
       potential <a>violation</a> on iframes resulted only in this report being
       generated.
+
+    - <dfn for="PermissionsPolicyViolationReportBody">allowAttribute</dfn>: If
+      known, the value of <{iframe}> element's <{iframe/allow}> attribute, or 
+      null otherwise.
 
   <section>
     <h3 id="permissions-policy-report-only-http-header-field">\``Permissions-Policy-Report-Only`\`
@@ -942,10 +947,11 @@ partial interface HTMLIFrameElement {
     policy</a>, which may be empty.
     1. If |element| is not an <{iframe}> element, then return an empty [=policy
        directive=].
+    1. Let |allowAttribute| be the value of |element|'s <{iframe/allow}>
+       attribute.
     1. Let |container policy| be the result of running <a abstract-op>Parse policy
-      directive</a> given the value of |element|'s <{iframe/allow}> attribute,
-      the [=Document/origin=] of |element|'s [=node document=], and |element|'s
-      <a>declared origin</a>.
+      directive</a> given |allowAttribute|, the [=Document/origin=] of |element|'s
+      [=node document=], and |element|'s <a>declared origin</a>.
     1. If |element|'s <{iframe/allowfullscreen}> attribute is specified, and
        |container policy| does not [=map/contain=] an entry for the
        <code>fullscreen</code> [=feature=].
@@ -956,7 +962,8 @@ partial interface HTMLIFrameElement {
          value <code>*</code></a>, then [=list/for each=] [=origins=] in
          <a>allowlist</a>:
         1. Executing <a abstract-op>Is feature enabled in document for origin?</a>
-           on |feature|, |element|'s [=node document=], |origin|, True, and True.
+           on |feature|, |element|'s [=node document=], |origin|, True, True, and
+           |allowAttribute|.
     1. Return |container policy|.
 
     </div>
@@ -1090,12 +1097,12 @@ partial interface HTMLIFrameElement {
     <div class="algorithm" data-algorithm="is-feature-enabled">
     Given a [=feature=] (|feature|), a {{Document}} object
     (|document|), an [=origin=] (|origin|), an optional boolean (|report|) with
-    a default value of True, and an optional boolean (|potential|) with a
-    default value of False, this algorithm returns "<code>Disabled</code>" if
-    |feature| should be considered disabled, and "<code>Enabled</code>"
-    otherwise. If |report| is True, then it will also [=generate and queue a
-    report=] if the feature is not enabled in either |document|'s
-    [=Document/permissions policy=] or |document|'s
+    a default value of True, an optional boolean (|potential|) with a default
+    value of False, and an optional string (|allowAttribute|), this algorithm
+    returns "<code>Disabled</code>" if |feature| should be considered disabled,
+    and "<code>Enabled</code>" otherwise. If |report| is True, then it will also
+    [=generate and queue a report=] if the feature is not enabled in either
+    |document|'s [=Document/permissions policy=] or |document|'s
     [=Document/report-only permissions policy=]</p>
 
     Note: The default value of True for |report| means that most permissions
@@ -1124,7 +1131,7 @@ partial interface HTMLIFrameElement {
                |potential| is True, or "<code>enforce</code>" otherwise.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,
-                |disposition|, and |endpoint|.
+                |disposition|, |endpoint|, and |allowAttribute|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
                 abstract-op>Get the reporting endpoint for a feature</a> given
@@ -1133,7 +1140,7 @@ partial interface HTMLIFrameElement {
                |potential| is True, or "<code>report</code>" otherwise.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,
-                |potential|, and |report-only endpoint|.
+                |potential|, |report-only endpoint|, and |allowAttribute|.
     1. Return result
 
     </div>
@@ -1157,9 +1164,9 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="report-permissions-policy-violation">
     Given a [=feature=] (|feature|), an <a>environment settings object</a>
-    (|settings|), a string (|disposition|), and a string-or-null (|endpoint|),
-    this algorithm generates a <a>report</a> about the <a>violation</a> of the
-    policy for |feature|.
+    (|settings|), a string (|disposition|), a string-or-null (|endpoint|), and
+    a string-or-null (|allowAttribute|), this algorithm generates a
+    <a>report</a> about the <a>violation</a> of the policy for |feature|.
 
     1. Let |body| be a new {{PermissionsPolicyViolationReportBody}}, initialized
       as follows:
@@ -1174,12 +1181,18 @@ partial interface HTMLIFrameElement {
         ::  null
         :   [=PermissionsPolicyViolationReportBody/disposition=]
         ::  |disposition|
+        :   [=PermissionsPolicyViolationReportBody/allowAttribute=]
+        ::  |allowAttribute|
 
     1. If the user agent is currently executing script, and can extract the
       source file's URL, line number, and column number from |settings|, then
       set |body|'s [=PermissionsPolicyViolationReportBody/sourceFile=],
       [=PermissionsPolicyViolationReportBody/lineNumber=], and
       [=PermissionsPolicyViolationReportBody/columnNumber=] accordingly.
+
+    1. If |allowAttribute| is not null, then set |body|'s
+       [=PermissionsPolicyViolationReportBody/allowAttribute=] to
+       |allowAttribute|.
 
     1. Execute [=generate and queue a report=] with |body|,
       "permissions-policy-violation", |endpoint|, and |settings|.

--- a/index.bs
+++ b/index.bs
@@ -951,6 +951,12 @@ partial interface HTMLIFrameElement {
        <code>fullscreen</code> [=feature=].
       1. [=map/Set=] |container policy|[<code>fullscreen</code>] = <a>the
          special value <code>*</code></a>.
+    1. [=map/For each=] [=feature=] in |container policy|:
+      1. If [=feature=]'s <a>allowlist</a> does not [=list/contain=] <a>the special
+         value <code>*</code></a>, then [=list/for each=] [=origins=] in
+         <a>allowlist</a>:
+        1. Executing <a abstract-op>Is feature enabled in document for origin?</a>
+           on |feature|, |element|'s [=node document=], |origin|, True, and True.
     1. Return |container policy|.
 
     </div>
@@ -1083,13 +1089,14 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="is-feature-enabled">
     Given a [=feature=] (|feature|), a {{Document}} object
-    (|document|), an [=origin=] (|origin|), and an optional boolean (|report|),
-    with a default value of True, this algorithm returns "<code>Disabled</code>"
-    if |feature| should be considered disabled, and "<code>Enabled</code>"
+    (|document|), an [=origin=] (|origin|), an optional boolean (|report|) with
+    a default value of True, and an optional boolean (|potential|) with a
+    default value of False, this algorithm returns "<code>Disabled</code>" if
+    |feature| should be considered disabled, and "<code>Enabled</code>"
     otherwise. If |report| is True, then it will also [=generate and queue a
     report=] if the feature is not enabled in either |document|'s
-    [=Document/permissions policy=] or |document|'s [=Document/report-only
-    permissions policy=]</p>
+    [=Document/permissions policy=] or |document|'s
+    [=Document/report-only permissions policy=]</p>
 
     Note: The default value of True for |report| means that most permissions
     policy checks will generate a violation report if the feature is not
@@ -1113,16 +1120,20 @@ partial interface HTMLIFrameElement {
             1. Let |endpoint| be the result of calling <a abstract-op>Get the
                 reporting endpoint for a feature</a> given |feature| and
                 |policy|.
+            1. Let |disposition| be "<code>potential-enforce</code>" if
+               |potential| is True, or "<code>enforce</code>" otherwise.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,
-                "<code>Enforce</code>", and |endpoint|.
+                |disposition|, and |endpoint|.
         1. Else, if |report-only result| is "<code>Disabled</code>":
             1. Let |report-only endpoint| be the result of calling <a
                 abstract-op>Get the reporting endpoint for a feature</a> given
                |feature| and |report-only policy|.
+            1. Let |disposition| be "<code>potential-report</code>" if
+               |potential| is True, or "<code>report</code>" otherwise.
             1. Call <a abstract-op>Generate report for violation of permissions
                 policy on settings</a> given |feature|, |settings|,
-                "<code>Report</code>", and |report-only endpoint|.
+                |potential|, and |report-only endpoint|.
     1. Return result
 
     </div>


### PR DESCRIPTION
This change implements permission policy reporting for potential Permissions Policy violations to parent frames.

Currently, Permissions Policy violations inside an iframe is not sent to parent frame, because of security concerns. However, this makes it difficult for websites to roll out Permissions Policy because the site owner does not have insight into permission breakage in iframes.

The change is implemented in a way that it does not leak any new information to parent frame, while sending signals that iframes might be affected by the Permissions Policy.

Fixes: https://github.com/w3c/webappsec-permissions-policy/issues/537


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shhnjk/webappsec-permissions-policy/pull/546.html" title="Last updated on Sep 23, 2024, 8:30 PM UTC (7f6eee5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/546/f15a454...shhnjk:7f6eee5.html" title="Last updated on Sep 23, 2024, 8:30 PM UTC (7f6eee5)">Diff</a>