### PR TITLE
Add two "JS playground" examples.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -123,7 +123,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     will actually be granted the ability to use that API.</p>
   </div>
   <div class="example">
-    <p>SecureCorp Inc. restructured its domains and now needs to needs to delegate
+    <p>SecureCorp Inc. restructured its domains and now needs to delegate
     use of the Geolocation API to its origin ("<code>https://example.com</code>")
     as well as three subdomains ("<code>https://geo.example.com</code>",
     "<code>https://geo2.example.com</code>", and "<code>https://new.geo2.example.com</code>").
@@ -162,6 +162,38 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     "<code>https://example.com:444</code>", and "<code>https://example.com:445</code>"
     to use the Geolocation API, but any other ports on "<code>https://example.com</code>"
     could use it too.</p>
+  </div>
+  <div class="example">
+    <p>JSPlaygroundCorp Inc. wants to host user-generated web applications, but wants the
+    browser to manage their permissions to use powerful features in isolation of each other.
+    This can be accomplished by creating discrete subdomains for each piece of web-content
+    or web-content creator, and navigating them as top-level documents (framework and
+    user-content can still be separated using same-origin iframes).
+
+    JSPlaygroundCorp should avoid iframing the web-content using the "<code>allow</code>"
+    attribute from its own domain.
+  </div>
+  <div class="example">
+    <p>PlatformCorp Inc. wants to offer a marketplace of embeddable third-party components
+    to build from or games to play. It wants to delegate
+    the use of powerful features like the getUserMedia API responsibly. It keeps
+    track of which components need a feature, using bespoke "install" UX to keep end-users
+    in charge.</p>
+    <p>Camera and microphone are disabled by default in all cross-origin frames.
+    Each third-party component has a subdomain, and can be embedded in a
+    cross-origin iframe. PlatformCorp can use the "<code>allow</code>" attribute on
+    the iframe element to control whether to delegate camera or microphone access or
+    not to each subdomain.
+    An iframe where "plugin1" and "plugin3" should have camera access and "plugin2"
+    should have microphone access might look like this:
+    <pre>
+    &lt;iframe
+     <a href="#iframe-allow-attribute">allow</a>="camera //plugin1.site.com //plugin3.site.com; microphone //plugin2.site.com"
+            src="//doc1.site.com" sandbox="allow-same-origin allow-scripts"&gt;&lt;/iframe&gt;
+    </pre>
+    <p>Iframe attributes can selectively enable features in certain frames, and
+    not in others, even if those contain documents from the same origin.
+    The list of sandbox tokens might be longer in practice.</p>
   </div>
 </section>
 <section>

--- a/index.bs
+++ b/index.bs
@@ -194,14 +194,20 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     An iframe where the component "app1" should have camera access, "app2" should
     have microphone access, and "app3" should have both might look like this:
     <pre>
-    &lt;iframe allow="camera //app1.site.com //app3.site.com; microphone //app2.site.com"
-            src="//doc1.site.com" sandbox="allow-same-origin allow-scripts"&gt;&lt;/iframe&gt;
+    &lt;iframe
+      allow="camera https://app1.site.com https://app3.site.com;
+             microphone https://app2.site.com https://app3.site.com"
+      src="https://doc1.site.com"
+      sandbox="allow-same-origin allow-scripts"&gt;
+    &lt;/iframe&gt;
     </pre>
     <p>Iframe attributes can selectively enable features in certain frames, and
     not in others, even if those contain documents from the [=same origin=].
     The list of sandbox tokens might be longer in practice.</p>
-    <p>If the user already trusts PlatformCorp then
-    there might not be any additional permission prompt in this case.</p>
+    <p>Since browsers generally ask users to grant permissions to the top-level
+    domain, there might not be any additional permission prompt for the
+    components to request camera or microphone access if the user already
+    trusts PlatformCorp.</p>
   </div>
 </section>
 <section>

--- a/index.bs
+++ b/index.bs
@@ -189,8 +189,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     Each third-party component has a subdomain, and can be embedded in a
     cross-origin iframe. PlatformCorp can use the <{iframe/allow}> attribute on
     the <{iframe}> element to control whether to delegate camera or microphone
-    access or not to each subdomain. If the user already trusts PlatformCorp then
-    there might be no additional permission prompt in this case.
+    access or not to each subdomain.
 
     An iframe where the component "app1" should have camera access, "app2" should
     have microphone access, and "app3" should have both might look like this:
@@ -201,6 +200,8 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     <p>Iframe attributes can selectively enable features in certain frames, and
     not in others, even if those contain documents from the [=same origin=].
     The list of sandbox tokens might be longer in practice.</p>
+    <p>If the user already trusts PlatformCorp then
+    there might not be any additional permission prompt in this case.</p>
   </div>
 </section>
 <section>

--- a/index.bs
+++ b/index.bs
@@ -23,6 +23,7 @@ spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
 spec:fetch; type:dfn; text:value
 spec:infra; type:dfn; text:list
+spec:permissions; type:dfn; text:feature
 </pre>
 <pre class="anchors">
 spec:payment-request; urlPrefix: https://w3c.github.io/payment-request/
@@ -170,25 +171,31 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
     or web-content creator, and navigating them as top-level documents (framework and
     user-content can still be separated using same-origin iframes).
 
-    JSPlaygroundCorp should avoid iframing the web-content using the "<code>allow</code>"
-    attribute from its own domain.
+    This is necessary since users grant permissions to the domain they perceive they
+    are interacting with in the browser, which is the top-level domain.
+
+    JSPlaygroundCorp should avoid iframing user-generated web applications using the
+    <{iframe/allow}> attribute from its own domain in this case, as this would grant
+    its domain permissions to all of them.
   </div>
   <div class="example">
-    <p>PlatformCorp Inc. wants to offer a marketplace of embeddable third-party components
-    to build from or games to play. It wants to delegate
-    the use of powerful features like the getUserMedia API responsibly. It keeps
-    track of which components need a feature, using bespoke "install" UX to keep end-users
-    in charge.</p>
+    <p>PlatformCorp Inc. wants to offer a marketplace of embeddable third-party
+    components to build from or games to play under its top-level domain. It wants to
+    delegate the use of [=powerful features=] like the {{MediaDevices/getUserMedia()}}
+    API responsibly. It accepts responsibility for tracking which of its component
+    applications need a feature, using bespoke "install" UX to keep end-users in
+    charge.</p>
     <p>Camera and microphone are disabled by default in all cross-origin frames.
     Each third-party component has a subdomain, and can be embedded in a
-    cross-origin iframe. PlatformCorp can use the "<code>allow</code>" attribute on
-    the iframe element to control whether to delegate camera or microphone access or
-    not to each subdomain.
-    An iframe where "plugin1" and "plugin3" should have camera access and "plugin2"
-    should have microphone access might look like this:
+    cross-origin iframe. PlatformCorp can use the <{iframe/allow}> attribute on
+    the <{iframe}> element to control whether to delegate camera or microphone
+    access or not to each subdomain. If the user already trusts PlatformCorp then
+    there might be no additional permission prompt in this case.
+
+    An iframe where the component "app1" should have camera access, "app2" should
+    have microphone access, and "app3" should have both might look like this:
     <pre>
-    &lt;iframe
-     <a href="#iframe-allow-attribute">allow</a>="camera //plugin1.site.com //plugin3.site.com; microphone //plugin2.site.com"
+    &lt;iframe allow="camera //app1.site.com //app3.site.com; microphone //app2.site.com"
             src="//doc1.site.com" sandbox="allow-same-origin allow-scripts"&gt;&lt;/iframe&gt;
     </pre>
     <p>Iframe attributes can selectively enable features in certain frames, and

--- a/index.bs
+++ b/index.bs
@@ -192,7 +192,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
             src="//doc1.site.com" sandbox="allow-same-origin allow-scripts"&gt;&lt;/iframe&gt;
     </pre>
     <p>Iframe attributes can selectively enable features in certain frames, and
-    not in others, even if those contain documents from the same origin.
+    not in others, even if those contain documents from the [=same origin=].
     The list of sandbox tokens might be longer in practice.</p>
   </div>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -165,7 +165,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   </div>
   <div class="example">
     <p>JSPlaygroundCorp Inc. wants to host user-generated web applications, but wants the
-    browser to manage their permissions to use powerful features in isolation of each other.
+    browser to manage their permissions to use [=powerful features=] in isolation of each other.
     This can be accomplished by creating discrete subdomains for each piece of web-content
     or web-content creator, and navigating them as top-level documents (framework and
     user-content can still be separated using same-origin iframes).


### PR DESCRIPTION
Fixes #547. How about something like this?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webappsec-permissions-policy/pull/548.html" title="Last updated on Jun 26, 2024, 7:36 PM UTC (8075bc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/548/7a2bc78...jan-ivar:8075bc0.html" title="Last updated on Jun 26, 2024, 7:36 PM UTC (8075bc0)">Diff</a>