### PR TITLE
Replace `shared-autofill` with `autofill` and `manual-text`

### DIFF
--- a/features.md
+++ b/features.md
@@ -73,11 +73,12 @@ integrated into their respective specs.
 
 | Feature name | Spec/PR link(s) | Browser Support |
 | ------------ | --------------- | --------------- |
+| `autofill` | https://github.com/explainers-by-googlers/safe-text-input/blob/main/autofill.md | |
 | `clipboard-read` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
 | `clipboard-write` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
 | `deferred-fetch` |https://github.com/whatwg/fetch/pull/1647 | |
 | `gamepad` | https://github.com/w3c/gamepad/pull/112 |  |
-| `shared-autofill` | https://github.com/schwering/shared-autofill | |
+| `manual-text` | https://github.com/explainers-by-googlers/safe-text-input/blob/main/manual-text.md | |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
 
 ## Experimental Features


### PR DESCRIPTION
The shared-autofill proposal has been revised to address the more general problem of (text) input in third-party documents: https://github.com/w3ctag/design-reviews/issues/831#issuecomment-2595715161