### PR TITLE
Do not use request's window concept

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1313,8 +1313,10 @@ partial interface HTMLIFrameElement {
     Given a [=policy-controlled feature|feature=] (|feature|) and a  <a for="/">request</a> (|request|),
     this algorithm returns <code>true</code> if the request should be allowed to
     use |feature|, and <code>false</code> otherwise.
-    1. Set |window| to |request|’s <a for="request">window</a>.
-    1. If |window| is not a {{Window}}, return <code>false</code>.
+    1. Let |client| be |request|’s [=request/client=].
+    1. If |client| is not an [=environment settings object=], return <code>false</code>.
+    1. If |client|'s [=environment settings object/global object=] is not a {{Window}}, return
+       <code>false</code>.
        <div class="issue">Permissions Policy within non-Window contexts
        ({{WorkerGlobalScope}} or {{WorkletGlobalScope}}) is being figured out in
        <a href="https://github.com/w3c/webappsec-permissions-policy/issues/207">issue
@@ -1322,7 +1324,8 @@ partial interface HTMLIFrameElement {
        initiated within these contexts to use policy-controlled features.
        *Until* that’s resolved, disallow all policy-controlled features (e.g.,
        sending Client Hints to third parties) in these contexts.</div>
-    1. Set |document| to |window|’s <a>associated `Document`</a>.
+    1. Set |document| to |client|’s [=environment settings object/global object=]’s
+       <a>associated `Document`</a>.
     1. Let |origin| be |request|’s <a for="request">origin</a>.
     1. Let |result| be the result of executing <a abstract-op>Is feature
       enabled in document for origin?</a> on |feature|, |document|, and |origin|.

--- a/index.bs
+++ b/index.bs
@@ -1314,7 +1314,7 @@ partial interface HTMLIFrameElement {
     this algorithm returns <code>true</code> if the request should be allowed to
     use |feature|, and <code>false</code> otherwise.
     1. Let |client| be |request|’s [=request/client=].
-    1. If |client| is not an [=environment settings object=], return <code>false</code>.
+    1. If |client| is null, return <code>false</code>.
     1. If |client|'s [=environment settings object/global object=] is not a {{Window}}, return
        <code>false</code>.
        <div class="issue">Permissions Policy within non-Window contexts


### PR DESCRIPTION
Per https://github.com/whatwg/fetch/pull/1823, this concept is going away. Instead, use the request's client, which is equivalent for this spec's purposes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/webappsec-permissions-policy/pull/565.html" title="Last updated on May 13, 2025, 8:40 AM UTC (20545b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/565/b5dde2c...domenic:20545b9.html" title="Last updated on May 13, 2025, 8:40 AM UTC (20545b9)">Diff</a>