### PR TITLE
Add proposed features from Chrome's Built-In AI APIs

### DIFF
--- a/features.md
+++ b/features.md
@@ -77,8 +77,14 @@ integrated into their respective specs.
 | `clipboard-write` | https://github.com/w3c/clipboard-apis/pull/120 | Chrome 86 |
 | `deferred-fetch` |https://github.com/whatwg/fetch/pull/1647 | |
 | `gamepad` | https://github.com/w3c/gamepad/pull/112 |  |
+| `language-detector` | https://github.com/webmachinelearning/translation-api | Chrome 138 |
+| `language-model` | https://github.com/webmachinelearning/prompt-api | |
+| `rewriter` | https://github.com/webmachinelearning/writing-assistance-apis | |
+| `summarizer` | https://github.com/webmachinelearning/writing-assistance-apis | Chrome 138 |
 | `shared-autofill` | https://github.com/schwering/shared-autofill | |
 | `speaker-selection` | https://github.com/w3c/mediacapture-output/pull/96 | |
+| `translator` | https://github.com/webmachinelearning/translation-api | Chrome 138 |
+| `writer` | https://github.com/webmachinelearning/writing-assistance-apis | |
 
 ## Experimental Features
 


### PR DESCRIPTION
For additional context see the relevant Chrome feature statuses, which also link to explainers/specs:
[Language Detector API](https://chromestatus.com/feature/6494349985841152), [Prompt API](https://chromestatus.com/feature/5134603979063296), [Rewriter API](https://chromestatus.com/feature/5112320150470656), [Summarizer API](https://chromestatus.com/feature/5193953788559360), [Translator API](https://chromestatus.com/feature/5172811302961152), [Writer API](https://chromestatus.com/feature/4712595362414592)